### PR TITLE
Try to fix macOS libomp linkage for conda

### DIFF
--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -17,8 +17,7 @@ jobs:
 
     - name: Install deps on macos
       if: contains( matrix.os, 'macos')
-      run: |
-        brew install coreutils || true
+      run: brew install coreutils || true
 
     - name: Install macOS SDK
       if: contains( matrix.os, 'macos')

--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -19,7 +19,6 @@ jobs:
       if: contains( matrix.os, 'macos')
       run: |
         brew install coreutils || true
-        brew remove -f libomp
 
     - name: Install macOS SDK
       if: contains( matrix.os, 'macos')

--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -17,7 +17,9 @@ jobs:
 
     - name: Install deps on macos
       if: contains( matrix.os, 'macos')
-      run: brew install coreutils || true
+      run: |
+        brew install coreutils || true
+        brew remove -f libomp
 
     - name: Install macOS SDK
       if: contains( matrix.os, 'macos')

--- a/conda/meta.yaml.in
+++ b/conda/meta.yaml.in
@@ -14,6 +14,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - mkl-devel {{ mkl }}
+    - llvm-openmp            # [osx]
     - cmake >=3.2
     - ninja
     - ccache
@@ -23,6 +24,7 @@ requirements:
 
   run:
     - {{ pin_compatible('mkl', upper_bound='2021.0') }}
+    - intel-openmp           # [linux]
 
 files:
   - include/libtensor


### PR DESCRIPTION
There's probably an issue with the `libomp` (due to clang) linkage in macOS builds on conda.
I think that maybe a system `libomp` (probably installed through brew?!) screws up...

Warning from conda-build:
```
WARNING (libtensorlight,lib/libtensorlight.dylib): $RPATH/libomp.dylib not found in packages, sysroot(s) nor the missing_dso_whitelist... is this binary repackaging?
```