### PR TITLE
Remove C++17 deprecated features 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:

--- a/cmake/SetupCompiler.cmake
+++ b/cmake/SetupCompiler.cmake
@@ -13,7 +13,7 @@ macro(enable_if_cxx_compiles VARIABLE FLAG)
 endmacro(enable_if_cxx_compiles)
 
 # Standard flags for building libtensor, used without check
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-error -Wno-unused-parameter")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-unused-but-set-variable")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds -Wno-maybe-uninitialized")
 

--- a/cmake/SetupCompiler.cmake
+++ b/cmake/SetupCompiler.cmake
@@ -13,8 +13,8 @@ macro(enable_if_cxx_compiles VARIABLE FLAG)
 endmacro(enable_if_cxx_compiles)
 
 # Standard flags for building libtensor, used without check
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-error -Wno-unused-parameter")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-deprecated -Wno-unused-but-set-variable")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-unused-but-set-variable")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds -Wno-maybe-uninitialized")
 
 # Really useful and sensible flags to check for common errors

--- a/libtensor/btod/btod_print.h
+++ b/libtensor/btod/btod_print.h
@@ -27,7 +27,7 @@ public:
     btod_print(std::ostream &stream, size_t pre = 16, bool sci = true) :
         m_stream(stream), m_precision(pre), m_sci(sci) { }
 
-    void perform(block_tensor_rd_i<N,double> &bt) throw(exception);
+    void perform(block_tensor_rd_i<N,double> &bt);
 };
 
 template<size_t N, typename Alloc>
@@ -35,8 +35,7 @@ const char *btod_print<N, Alloc>::k_clazz = "btod_print<N, Alloc>";
 
 
 template<size_t N, typename Alloc>
-void btod_print<N, Alloc>::perform(
-        block_tensor_rd_i<N, double> &bt) throw(exception)
+void btod_print<N, Alloc>::perform(block_tensor_rd_i<N, double> &bt)
 {
     static const char *method = "perform(block_tensor_rd_i<N, double>&)";
 

--- a/libtensor/core/allocator.h
+++ b/libtensor/core/allocator.h
@@ -29,7 +29,7 @@ public:
     virtual void shutdown() = 0;
     virtual size_t get_block_size(size_t sz) = 0;
     virtual pointer_type allocate(size_t sz) = 0;
-    virtual void deallocate(const pointer_type &p) throw () = 0;
+    virtual void deallocate(const pointer_type &p) = 0;
     virtual void prefetch(const pointer_type &p) = 0;
     virtual T *lock_rw(const pointer_type &p) = 0;
     virtual const T *lock_ro(const pointer_type &p) = 0;
@@ -102,7 +102,7 @@ public:
             allocated by allocate()
         \param p Virtual memory pointer.
      **/
-    static void deallocate(const pointer_type &p) throw () {
+    static void deallocate(const pointer_type &p) {
         m_aimpl->deallocate(p);
     }
 

--- a/libtensor/core/allocator.h
+++ b/libtensor/core/allocator.h
@@ -29,7 +29,7 @@ public:
     virtual void shutdown() = 0;
     virtual size_t get_block_size(size_t sz) = 0;
     virtual pointer_type allocate(size_t sz) = 0;
-    virtual void deallocate(const pointer_type &p) = 0;
+    virtual void deallocate(const pointer_type &p) noexcept = 0;
     virtual void prefetch(const pointer_type &p) = 0;
     virtual T *lock_rw(const pointer_type &p) = 0;
     virtual const T *lock_ro(const pointer_type &p) = 0;

--- a/libtensor/core/bad_block_index_space.h
+++ b/libtensor/core/bad_block_index_space.h
@@ -20,13 +20,13 @@ public:
      **/
     bad_block_index_space(const char *ns, const char *clazz,
         const char *method, const char *file, unsigned int line,
-        const char *message) throw() :
+        const char *message) noexcept :
         exception_base<bad_block_index_space>(ns, clazz, method,
             file, line, "bad_block_index_space", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_block_index_space() throw() { };
+    virtual ~bad_block_index_space() noexcept { };
 
     //@}
 };

--- a/libtensor/core/bad_block_index_space.h
+++ b/libtensor/core/bad_block_index_space.h
@@ -20,13 +20,13 @@ public:
      **/
     bad_block_index_space(const char *ns, const char *clazz,
         const char *method, const char *file, unsigned int line,
-        const char *message) throw() :
+        const char *message) :
         exception_base<bad_block_index_space>(ns, clazz, method,
             file, line, "bad_block_index_space", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_block_index_space() throw() { };
+    virtual ~bad_block_index_space() { };
 
     //@}
 };

--- a/libtensor/core/bad_dimensions.h
+++ b/libtensor/core/bad_dimensions.h
@@ -20,13 +20,13 @@ public:
      **/
     bad_dimensions(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw() :
+        noexcept :
         exception_base<bad_dimensions>(ns, clazz, method, file, line,
             "bad_dimensions", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_dimensions() throw() { };
+    virtual ~bad_dimensions() noexcept { };
 
     //@}
 };

--- a/libtensor/core/bad_dimensions.h
+++ b/libtensor/core/bad_dimensions.h
@@ -19,14 +19,13 @@ public:
     /** \brief Creates an exception
      **/
     bad_dimensions(const char *ns, const char *clazz, const char *method,
-        const char *file, unsigned int line, const char *message)
-        throw() :
+        const char *file, unsigned int line, const char *message) :
         exception_base<bad_dimensions>(ns, clazz, method, file, line,
             "bad_dimensions", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_dimensions() throw() { };
+    virtual ~bad_dimensions() { };
 
     //@}
 };

--- a/libtensor/core/block_index_space.h
+++ b/libtensor/core/block_index_space.h
@@ -187,15 +187,13 @@ public:
         \param idx Block %index.
         \throw out_of_bounds If the block %index is out of bounds.
      **/
-    index<N> get_block_start(const index<N> &idx) const
-        throw(out_of_bounds);
+    index<N> get_block_start(const index<N> &idx) const;
 
     /** \brief Returns the %dimensions of a block
         \param idx Block index.
         \throw out_of_bounds If the block %index is out of bounds.
      **/
-    dimensions<N> get_block_dims(const index<N> &idx) const
-        throw(out_of_bounds);
+    dimensions<N> get_block_dims(const index<N> &idx) const;
 
     //@}
 
@@ -207,13 +205,13 @@ public:
         \param dim Dimension number.
         \throw out_of_bounds If the dimension number is out of bounds.
      **/
-    size_t get_type(size_t dim) const throw(out_of_bounds);
+    size_t get_type(size_t dim) const;
 
     /** \brief Returns splitting points
         \param typ Dimension type (see get_type())
         \throw out_of_bounds If the dimension type is out of bounds.
      **/
-    const split_points &get_splits(size_t typ) const throw(out_of_bounds);
+    const split_points &get_splits(size_t typ) const;
 
     /** \brief Adds a split point for a subspace identified by a %mask
         \param msk Dimension mask.
@@ -222,8 +220,7 @@ public:
         \throw bad_parameter If the mask is incorrect.
         \throw out_of_bounds If the position is out of bounds.
      **/
-    void split(const mask<N> &msk, size_t pos)
-        throw(bad_parameter, out_of_bounds);
+    void split(const mask<N> &msk, size_t pos);
 
     /** \brief Attempts to match subspaces that have the same splitting
             patterns, but are assigned different types
@@ -309,8 +306,7 @@ dimensions<N> block_index_space<N>::get_block_index_dims() const {
 
 
 template<size_t N>
-index<N> block_index_space<N>::get_block_start(const index<N> &idx) const
-    throw(out_of_bounds) {
+index<N> block_index_space<N>::get_block_start(const index<N> &idx) const {
 
     static const char *method = "get_block_start(const index<N>&)";
 
@@ -335,8 +331,7 @@ index<N> block_index_space<N>::get_block_start(const index<N> &idx) const
 
 
 template<size_t N>
-dimensions<N> block_index_space<N>::get_block_dims(const index<N> &idx) const
-    throw(out_of_bounds) {
+dimensions<N> block_index_space<N>::get_block_dims(const index<N> &idx) const {
 
     static const char *method = "get_block_dims(const index<N>&)";
 
@@ -363,16 +358,13 @@ dimensions<N> block_index_space<N>::get_block_dims(const index<N> &idx) const
 
 
 template<size_t N>
-inline size_t block_index_space<N>::get_type(size_t dim) const
-    throw(out_of_bounds) {
-
+inline size_t block_index_space<N>::get_type(size_t dim) const {
     return m_type[dim];
 }
 
 
 template<size_t N>
-inline const split_points &block_index_space<N>::get_splits(size_t typ) const
-    throw(out_of_bounds) {
+inline const split_points &block_index_space<N>::get_splits(size_t typ) const {
 
     static const char *method = "get_splits(size_t)";
 
@@ -415,8 +407,7 @@ bool block_index_space<N>::equals(const block_index_space<N> &bis) const {
 
 
 template<size_t N>
-void block_index_space<N>::split(const mask<N> &msk, size_t pos)
-    throw(bad_parameter, out_of_bounds) {
+void block_index_space<N>::split(const mask<N> &msk, size_t pos) {
 
     static const char *method = "split(const mask<N>&, size_t)";
 

--- a/libtensor/core/block_index_space.h
+++ b/libtensor/core/block_index_space.h
@@ -315,7 +315,7 @@ index<N> block_index_space<N>::get_block_start(const index<N> &idx) const
     static const char *method = "get_block_start(const index<N>&)";
 
 #ifdef LIBTENSOR_DEBUG
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(idx[i] > m_nsplits[i]) {
             throw out_of_bounds(g_ns, k_clazz, method,
                 __FILE__, __LINE__,
@@ -341,7 +341,7 @@ dimensions<N> block_index_space<N>::get_block_dims(const index<N> &idx) const
     static const char *method = "get_block_dims(const index<N>&)";
 
 #ifdef LIBTENSOR_DEBUG
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(idx[i] > m_nsplits[i]) {
             throw out_of_bounds(g_ns, k_clazz, method,
                 __FILE__, __LINE__,
@@ -536,9 +536,9 @@ template<size_t N>
 void block_index_space<N>::init_types() {
 
     size_t lasttype = 0;
-    for(register size_t i = 0; i != N; i++) {
+    for(size_t i = 0; i != N; i++) {
         size_t type = lasttype;
-        for(register size_t j = 0; j < i; j++) {
+        for(size_t j = 0; j < i; j++) {
             if(m_dims[i] == m_dims[j]) {
                 type = m_type[j];
                 break;

--- a/libtensor/core/contraction2.h
+++ b/libtensor/core/contraction2.h
@@ -256,10 +256,10 @@ void contraction2<N, M, K>::permute_a(const permutation<k_ordera> &perma)
     sequence<k_ordera, size_t> seqa(0);
     sequence<k_orderc, size_t> seqc1(0), seqc2(0);
     make_seqc(seqc1);
-    for(register size_t i = 0; i < k_ordera; i++)
+    for(size_t i = 0; i < k_ordera; i++)
         seqa[i] = m_conn[k_orderc + i];
     perma.apply(seqa);
-    for(register size_t i = 0; i < k_ordera; i++) {
+    for(size_t i = 0; i < k_ordera; i++) {
         m_conn[k_orderc + i] = seqa[i];
         m_conn[seqa[i]] = k_orderc + i;
     }
@@ -283,10 +283,10 @@ void contraction2<N, M, K>::permute_b(const permutation<k_orderb> &permb)
     sequence<k_orderb, size_t> seqb(0);
     sequence<k_orderc, size_t> seqc1(0), seqc2(0);
     make_seqc(seqc1);
-    for(register size_t i = 0; i < k_orderb; i++)
+    for(size_t i = 0; i < k_orderb; i++)
         seqb[i] = m_conn[k_orderc + k_ordera + i];
     permb.apply(seqb);
-    for(register size_t i = 0; i < k_orderb; i++) {
+    for(size_t i = 0; i < k_orderb; i++) {
         m_conn[k_orderc + k_ordera + i] = seqb[i];
         m_conn[seqb[i]] = k_orderc + k_ordera + i;
     }
@@ -328,7 +328,7 @@ void contraction2<N, M, K>::connect() {
 template<size_t N, size_t M, size_t K>
 void contraction2<N, M, K>::make_seqc(sequence<k_orderc, size_t> &seqc) {
 
-    for(register size_t i = 0, j = 0; i < k_ordera + k_orderb; i++) {
+    for(size_t i = 0, j = 0; i < k_ordera + k_orderb; i++) {
         if(m_conn[k_orderc + i] < k_orderc) {
             seqc[j++] = m_conn[k_orderc + i];
         }
@@ -340,7 +340,7 @@ void contraction2<N, M, K>::adjust_permc(sequence<k_orderc, size_t> &seqc1,
     sequence<k_orderc, size_t> &seqc2) {
 
     size_t seqcc1[k_orderc], seqcc2[k_orderc];
-    for(register size_t i = 0; i < k_orderc; i++) {
+    for(size_t i = 0; i < k_orderc; i++) {
         seqcc1[i] = seqc1[i];
         seqcc2[i] = seqc2[i];
     }

--- a/libtensor/core/contraction2.h
+++ b/libtensor/core/contraction2.h
@@ -97,30 +97,29 @@ public:
         \throw exception if index numbers are invalid or this
             contraction is complete.
      **/
-    void contract(size_t ia, size_t ib) throw (exception);
+    void contract(size_t ia, size_t ib);
 
     /** \brief Adjusts %index numbering when the argument A comes in a
             permuted form
         \param perma Permutation of the %tensor argument A.
         \throw exception if the contraction is incomplete.
      **/
-    void permute_a(const permutation<k_ordera> &perma) throw(exception);
+    void permute_a(const permutation<k_ordera> &perma);
 
     /** \brief Adjusts %index numbering when the argument B comes in a
             permuted form
         \param permb Permutation of the %tensor argument B.
         \throw exception if the contraction is incomplete.
      **/
-    void permute_b(const permutation<k_orderb> &permb) throw(exception);
+    void permute_b(const permutation<k_orderb> &permb);
 
     /** \brief Adjusts %index numbering when the result comes in a
             permuted form
         \param permc Permutation of the result (c).
      **/
-    void permute_c(const permutation<k_orderc> &permc) throw(exception);
+    void permute_c(const permutation<k_orderc> &permc);
 
-    const sequence<2 * (N + M + K), size_t> &get_conn() const
-        throw(exception);
+    const sequence<2 * (N + M + K), size_t> &get_conn() const;
 
     //@}
 
@@ -202,7 +201,7 @@ inline bool contraction2<N, M, K>::is_complete() const {
 }
 
 template<size_t N, size_t M, size_t K>
-void contraction2<N, M, K>::contract(size_t ia, size_t ib) throw (exception) {
+void contraction2<N, M, K>::contract(size_t ia, size_t ib) {
 
     static const char *method = "contract(size_t, size_t)";
 
@@ -242,8 +241,7 @@ void contraction2<N, M, K>::contract(size_t ia, size_t ib) throw (exception) {
 }
 
 template<size_t N, size_t M, size_t K>
-void contraction2<N, M, K>::permute_a(const permutation<k_ordera> &perma)
-    throw(exception) {
+void contraction2<N, M, K>::permute_a(const permutation<k_ordera> &perma) {
 
     static const char *method = "permute_a(const permutation<N + K>&)";
 
@@ -269,8 +267,7 @@ void contraction2<N, M, K>::permute_a(const permutation<k_ordera> &perma)
 }
 
 template<size_t N, size_t M, size_t K>
-void contraction2<N, M, K>::permute_b(const permutation<k_orderb> &permb)
-    throw(exception) {
+void contraction2<N, M, K>::permute_b(const permutation<k_orderb> &permb) {
 
     static const char *method = "permute_b(const permutation<M + K>&)";
 
@@ -296,8 +293,7 @@ void contraction2<N, M, K>::permute_b(const permutation<k_orderb> &permb)
 }
 
 template<size_t N, size_t M, size_t K>
-void contraction2<N, M, K>::permute_c(const permutation<k_orderc> &permc)
-    throw(exception) {
+void contraction2<N, M, K>::permute_c(const permutation<k_orderc> &permc) {
 
     if(!is_complete()) {
         throw_exc("contraction2<N, M, K>", "permute_c()",
@@ -310,7 +306,7 @@ void contraction2<N, M, K>::permute_c(const permutation<k_orderc> &permc)
 
 template<size_t N, size_t M, size_t K>
 inline const sequence<2 * (N + M + K), size_t>&
-contraction2<N, M, K>::get_conn() const throw(exception) {
+contraction2<N, M, K>::get_conn() const {
 
     if(!is_complete()) {
         throw_exc("contraction2<N, M, K>", "get_conn()",

--- a/libtensor/core/contraction2_list_builder.h
+++ b/libtensor/core/contraction2_list_builder.h
@@ -103,11 +103,11 @@ void contraction2_list_builder<N, M, K>::populate(ListT &list,
     sequence<k_orderc, size_t> dimc1(0);
 
     for(size_t i = k_orderc; i < k_orderc + k_ordera; i++) {
-        register size_t iconn = conn[i];
+        size_t iconn = conn[i];
         if(iconn < k_orderc) dimc1[iconn] = dima[i - k_orderc];
     }
     for(size_t i = k_orderc + k_ordera; i < k_maxconn; i++) {
-        register size_t iconn = conn[i];
+        size_t iconn = conn[i];
         if(iconn < k_orderc) {
             dimc1[iconn] = dimb[i - k_orderc - k_ordera];
         } else if(dima[iconn - k_orderc] !=
@@ -138,34 +138,34 @@ void contraction2_list_builder<N, M, K>::populate(ListT &list,
         // Here the first index from inode comes from c or a
         // If the index comes from c, make ica->c iab->a or b
         // If the index comes from a, make ica->a iab->b
-        register size_t ica = m_nodes[inode], iab = conn[ica];
+        size_t ica = m_nodes[inode], iab = conn[ica];
 
         // Calculate node weight and increments
         if(ica < k_orderc && iab < k_orderc + k_ordera) {
             // The index comes from a and goes to c
-            register size_t sz = m_nodesz[inode];
-            for(register size_t j = 0; j < sz; j++)
+            size_t sz = m_nodesz[inode];
+            for(size_t j = 0; j < sz; j++)
                 weight *= dima[iab + j - k_orderc];
             inca = dima.get_increment(iab + sz - k_orderc - 1);
             incb = 0;
             incc = 1;
-            for(register size_t j = k_orderc - 1; j >= ica + sz; j--)
+            for(size_t j = k_orderc - 1; j >= ica + sz; j--)
                 incc *= dimc[j];
         } else if(ica < k_orderc) {
             // The index comes from b and goes to c
-            register size_t sz = m_nodesz[inode];
-            for(register size_t j = 0; j < sz; j++)
+            size_t sz = m_nodesz[inode];
+            for(size_t j = 0; j < sz; j++)
                 weight *= dimb[iab + j - k_orderc - k_ordera];
             inca = 0;
             incb = dimb.get_increment(
                 iab + sz - k_orderc - k_ordera - 1);
             incc = 1;
-            for(register size_t j = k_orderc - 1; j >= ica + sz; j--)
+            for(size_t j = k_orderc - 1; j >= ica + sz; j--)
                 incc *= dimc[j];
         } else {
             // The index comes from a and b and gets contracted
-            register size_t sz = m_nodesz[inode];
-            for(register size_t j = 0; j < sz; j++)
+            size_t sz = m_nodesz[inode];
+            for(size_t j = 0; j < sz; j++)
                 weight *= dima[ica + j - k_orderc];
             inca = dima.get_increment(ica + sz - k_orderc - 1);
             incb = dimb.get_increment(

--- a/libtensor/core/contraction2_list_builder.h
+++ b/libtensor/core/contraction2_list_builder.h
@@ -51,8 +51,7 @@ public:
     /** \brief Constructor
     	\param contr Object describing the contraction
      **/
-    contraction2_list_builder(const contraction2<N, M, K> &contr)
-        throw(bad_parameter, out_of_bounds);
+    contraction2_list_builder(const contraction2<N, M, K> &contr);
 
     /** \brief Populate the optimized list according to the tensor dimensions
     		given
@@ -64,10 +63,10 @@ public:
     template<typename ListT>
     void populate(ListT &list, const dimensions<k_ordera> &dima,
         const dimensions<k_orderb> &dimb,
-        const dimensions<k_orderc> &dimc) const throw(exception);
+        const dimensions<k_orderc> &dimc) const;
 
 private:
-    void fuse() throw(out_of_bounds);
+    void fuse();
 };
 
 
@@ -78,7 +77,7 @@ const char *contraction2_list_builder<N, M, K>::k_clazz =
 
 template<size_t N, size_t M, size_t K>
 contraction2_list_builder<N, M, K>::contraction2_list_builder(
-    const contraction2<N, M, K> &contr) throw(bad_parameter, out_of_bounds)
+    const contraction2<N, M, K> &contr)
 : m_contr(contr), m_num_nodes(0), m_nodes(0), m_nodesz(0) {
 
     static const char *method =
@@ -97,7 +96,7 @@ template<size_t N, size_t M, size_t K>
 template<typename ListT>
 void contraction2_list_builder<N, M, K>::populate(ListT &list,
     const dimensions<k_ordera> &dima, const dimensions<k_orderb> &dimb,
-    const dimensions<k_orderc> &dimc) const throw (exception) {
+    const dimensions<k_orderc> &dimc) const {
 
     const sequence<k_maxconn, size_t> &conn = m_contr.get_conn();
     sequence<k_orderc, size_t> dimc1(0);
@@ -180,7 +179,7 @@ void contraction2_list_builder<N, M, K>::populate(ListT &list,
 
 
 template<size_t N, size_t M, size_t K>
-void contraction2_list_builder<N, M, K>::fuse() throw(out_of_bounds) {
+void contraction2_list_builder<N, M, K>::fuse() {
 
     const sequence<k_maxconn, size_t> &conn = m_contr.get_conn();
 

--- a/libtensor/core/impl/abs_index_impl.h
+++ b/libtensor/core/impl/abs_index_impl.h
@@ -56,7 +56,7 @@ bool abs_index<N>::inc() {
     do {
         if(m_idx[n] < m_dims[n] - 1) {
             m_idx[n]++;
-            for(register size_t i = n + 1; i != N; i++) m_idx[i] = 0;
+            for(size_t i = n + 1; i != N; i++) m_idx[i] = 0;
             done = true;
             ok = true;
         } else {
@@ -86,7 +86,7 @@ size_t abs_index<N>::get_abs_index(const index<N> &idx,
 #endif // LIBTENSOR_DEBUG
 
     size_t aidx = 0;
-    for(register size_t i = 0; i != N; i++) {
+    for(size_t i = 0; i != N; i++) {
         aidx += dims.get_increment(i) * idx[i];
     }
 
@@ -109,7 +109,7 @@ void abs_index<N>::get_index(size_t aidx, const dimensions<N> &dims,
 
     size_t a = aidx;
     size_t imax = N - 1;
-    for(register size_t i = 0; i < imax; i++) {
+    for(size_t i = 0; i < imax; i++) {
         idx[i] = a / dims.get_increment(i);
         a %= dims.get_increment(i);
     }
@@ -131,7 +131,7 @@ void abs_index<N>::get_index(size_t aidx, const magic_dimensions<N> &mdims,
 #endif // LIBTENSOR_DEBUG
 
     uint64_t a = aidx;
-    for(register size_t i = 0; i != N - 1; i++) {
+    for(size_t i = 0; i != N - 1; i++) {
         idx[i] = mdims.divide(a, i);
         a -= idx[i] * mdims.get_dims().get_increment(i);
     }

--- a/libtensor/core/impl/allocator_wrapper.h
+++ b/libtensor/core/impl/allocator_wrapper.h
@@ -51,7 +51,7 @@ public:
         return ptr.p1;
     }
 
-    virtual void deallocate(const pointer_type &p) {
+    virtual void deallocate(const pointer_type &p) noexcept {
         m_impl.deallocate(convp(p));
     }
 

--- a/libtensor/core/impl/allocator_wrapper.h
+++ b/libtensor/core/impl/allocator_wrapper.h
@@ -51,7 +51,7 @@ public:
         return ptr.p1;
     }
 
-    virtual void deallocate(const pointer_type &p) throw () {
+    virtual void deallocate(const pointer_type &p) {
         m_impl.deallocate(convp(p));
     }
 

--- a/libtensor/core/impl/dimensions_impl.h
+++ b/libtensor/core/impl/dimensions_impl.h
@@ -10,7 +10,7 @@ template<size_t N>
 dimensions<N>::dimensions(const index_range<N> &ir) {
 
     const index<N> &i0 = ir.get_begin(), &i1 = ir.get_end();
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         m_dims[i] = i1[i] - i0[i] + 1;
     }
     update_increments();
@@ -28,7 +28,7 @@ dimensions<N>::dimensions(const dimensions<N> &d) :
 template<size_t N>
 bool dimensions<N>::contains(const index<N> &idx) const {
 
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(idx[i] >= m_dims[i]) return false;
     }
     return true;
@@ -38,7 +38,7 @@ bool dimensions<N>::contains(const index<N> &idx) const {
 template<size_t N>
 bool dimensions<N>::equals(const dimensions<N> &d) const {
 
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(m_dims[i] != d.m_dims[i]) return false;
     }
     return true;
@@ -57,8 +57,8 @@ dimensions<N> &dimensions<N>::permute(const permutation<N> &p) {
 template<size_t N>
 void dimensions<N>::update_increments() {
 
-    register size_t sz = 1;
-    register size_t i = N;
+    size_t sz = 1;
+    size_t i = N;
     while(i != 0) {
         i--;
         m_incs[i] = sz;

--- a/libtensor/core/impl/magic_dimensions_impl.h
+++ b/libtensor/core/impl/magic_dimensions_impl.h
@@ -60,7 +60,7 @@ void magic_dimensions<N>::divide(const index<N> &i1, index<N> &i2) const {
     typedef sequence<N, libdivide::libdivide_u64_t> seq_t;
 
     const seq_t &magic = *reinterpret_cast<const seq_t*>(m_magic);
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         i2[i] = libdivide::libdivide_u64_do(i1[i], &magic[i]);
     }
 }

--- a/libtensor/core/index.h
+++ b/libtensor/core/index.h
@@ -188,7 +188,7 @@ inline index<N> &index<N>::permute(const permutation<N> &perm) {
 template<size_t N>
 inline bool index<N>::equals(const index<N> &idx) const {
 
-    for(register size_t i = 0; i < N; i++)
+    for(size_t i = 0; i < N; i++)
         if(sequence<N, size_t>::at_nothrow(i) !=
             idx.sequence<N, size_t>::at_nothrow(i)) return false;
     return true;
@@ -197,7 +197,7 @@ inline bool index<N>::equals(const index<N> &idx) const {
 template<size_t N>
 inline bool index<N>::less(const index<N> &idx) const {
 
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(sequence<N, size_t>::at_nothrow(i) <
             idx.sequence<N, size_t>::at_nothrow(i)) return true;
         if(sequence<N, size_t>::at_nothrow(i) >

--- a/libtensor/core/index_range.h
+++ b/libtensor/core/index_range.h
@@ -59,8 +59,8 @@ template<size_t N>
 inline index_range<N>::index_range(const index<N> &begin, const index<N> &end) :
     m_begin(begin), m_end(end) {
 
-    for(register size_t i=0; i != N; i++) if(m_begin[i] > m_end[i]) {
-        register size_t t = m_end[i];
+    for(size_t i=0; i != N; i++) if(m_begin[i] > m_end[i]) {
+        size_t t = m_end[i];
         m_end[i] = m_begin[i]; m_begin[i] = t;
     }
 }

--- a/libtensor/core/index_range.h
+++ b/libtensor/core/index_range.h
@@ -51,7 +51,7 @@ public:
 
     /** \brief Permutes both indices defining the range
     **/
-    index_range<N> &permute(const permutation<N> &p) throw(exception);
+    index_range<N> &permute(const permutation<N> &p);
 
 };
 
@@ -86,8 +86,7 @@ inline bool index_range<N>::equals(const index_range<N> &r) const {
 }
 
 template<size_t N>
-inline index_range<N> &index_range<N>::permute(const permutation<N> &p)
-    throw(exception) {
+inline index_range<N> &index_range<N>::permute(const permutation<N> &p) {
     m_begin.permute(p); m_end.permute(p);
     return *this;
 }

--- a/libtensor/core/mask.h
+++ b/libtensor/core/mask.h
@@ -81,7 +81,7 @@ mask<N>::mask(const mask<N> &msk) : sequence<N, bool>(msk) {
 template<size_t N>
 bool mask<N>::equals(const mask<N> &msk) const {
 
-    for(register size_t i = 0; i < N; i++)
+    for(size_t i = 0; i < N; i++)
         if(sequence<N, bool>::at_nothrow(i) !=
             msk.sequence<N, bool>::at_nothrow(i)) return false;
     return true;
@@ -99,7 +99,7 @@ mask<N> &mask<N>::permute(const permutation<N> &perm) {
 template<size_t N>
 mask<N> &mask<N>::operator|=(const mask<N> &other) {
 
-    for(register size_t i = 0; i != N; i++) {
+    for(size_t i = 0; i != N; i++) {
         sequence<N, bool>::at_nothrow(i) =
             sequence<N, bool>::at_nothrow(i) ||
                 other.sequence<N, bool>::at_nothrow(i);
@@ -112,7 +112,7 @@ template<size_t N>
 mask<N> mask<N>::operator|(const mask<N> &other) const {
 
     mask<N> m;
-    for(register size_t i = 0; i != N; i++) {
+    for(size_t i = 0; i != N; i++) {
         m.sequence<N, bool>::at_nothrow(i) =
             sequence<N, bool>::at_nothrow(i) ||
             other.sequence<N, bool>::at_nothrow(i);
@@ -124,7 +124,7 @@ mask<N> mask<N>::operator|(const mask<N> &other) const {
 template<size_t N>
 mask<N> &mask<N>::operator&=(const mask<N> &other) {
 
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         sequence<N, bool>::at_nothrow(i) =
             sequence<N, bool>::at_nothrow(i) &&
                 other.sequence<N, bool>::at_nothrow(i);
@@ -137,7 +137,7 @@ template<size_t N>
 mask<N> mask<N>::operator&(const mask<N> &other) const {
 
     mask<N> m;
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         m.sequence<N, bool>::at_nothrow(i) =
             sequence<N, bool>::at_nothrow(i) &&
             other.sequence<N, bool>::at_nothrow(i);

--- a/libtensor/core/out_of_bounds.h
+++ b/libtensor/core/out_of_bounds.h
@@ -19,13 +19,13 @@ public:
      **/
     out_of_bounds(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
+        noexcept
         : exception_base<out_of_bounds>(ns, clazz, method, file, line,
             "out_of_bounds", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~out_of_bounds() throw() { };
+    virtual ~out_of_bounds() noexcept { };
 
     //@}
 };

--- a/libtensor/core/out_of_bounds.h
+++ b/libtensor/core/out_of_bounds.h
@@ -19,13 +19,12 @@ public:
      **/
     out_of_bounds(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
         : exception_base<out_of_bounds>(ns, clazz, method, file, line,
             "out_of_bounds", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~out_of_bounds() throw() { };
+    virtual ~out_of_bounds() { };
 
     //@}
 };

--- a/libtensor/core/permutation.h
+++ b/libtensor/core/permutation.h
@@ -121,7 +121,7 @@ public:
         \return Reference to this %permutation.
         \throw out_of_bounds If either of the indices is out of bounds.
      **/
-    permutation<N> &permute(size_t i, size_t j) throw(out_of_bounds);
+    permutation<N> &permute(size_t i, size_t j);
 
     /** \brief Inverts the %permutation
         \return Reference to this %permutation.
@@ -238,8 +238,7 @@ inline permutation<N> &permutation<N>::permute(const permutation<N> &p) {
 
 
 template<size_t N>
-inline permutation<N> &permutation<N>::permute(size_t i, size_t j)
-    throw(out_of_bounds) {
+inline permutation<N> &permutation<N>::permute(size_t i, size_t j) {
 
 #ifdef LIBTENSOR_DEBUG
     if(i >= N || j >= N) {

--- a/libtensor/core/permutation.h
+++ b/libtensor/core/permutation.h
@@ -212,7 +212,7 @@ const char *permutation<N>::k_clazz = "permutation<N>";
 template<size_t N>
 inline permutation<N>::permutation() {
 
-    for(register size_t i = 0; i < N; i++) m_idx[i] = i;
+    for(size_t i = 0; i < N; i++) m_idx[i] = i;
 }
 
 
@@ -220,9 +220,9 @@ template<size_t N>
 inline permutation<N>::permutation(const permutation<N> &p, bool b_inverse) {
 
     if(b_inverse) {
-        for(register size_t i = 0; i < N; i++) m_idx[p.m_idx[i]] = i;
+        for(size_t i = 0; i < N; i++) m_idx[p.m_idx[i]] = i;
     } else {
-        for(register size_t i = 0; i < N; i++) m_idx[i] = p.m_idx[i];
+        for(size_t i = 0; i < N; i++) m_idx[i] = p.m_idx[i];
     }
 }
 
@@ -231,8 +231,8 @@ template<size_t N>
 inline permutation<N> &permutation<N>::permute(const permutation<N> &p) {
 
     size_t idx_cp[N];
-    for(register size_t i = 0; i < N; i++) idx_cp[i] = m_idx[i];
-    for(register size_t i = 0; i < N; i++) m_idx[i] = idx_cp[p.m_idx[i]];
+    for(size_t i = 0; i < N; i++) idx_cp[i] = m_idx[i];
+    for(size_t i = 0; i < N; i++) m_idx[i] = idx_cp[p.m_idx[i]];
     return *this;
 }
 
@@ -248,7 +248,7 @@ inline permutation<N> &permutation<N>::permute(size_t i, size_t j)
     }
 #endif // LIBTENSOR_DEBUG
     if(i == j) return *this;
-    register size_t i_cp = m_idx[i];
+    size_t i_cp = m_idx[i];
     m_idx[i] = m_idx[j];
     m_idx[j] = i_cp;
     return *this;
@@ -259,8 +259,8 @@ template<size_t N>
 inline permutation<N> &permutation<N>::invert() {
 
     size_t idx_cp[N];
-    for(register size_t i = 0; i < N; i++) idx_cp[i] = m_idx[i];
-    for(register size_t i = 0; i < N; i++) m_idx[idx_cp[i]] = i;
+    for(size_t i = 0; i < N; i++) idx_cp[i] = m_idx[i];
+    for(size_t i = 0; i < N; i++) m_idx[idx_cp[i]] = i;
     return *this;
 }
 
@@ -268,14 +268,14 @@ inline permutation<N> &permutation<N>::invert() {
 template<size_t N>
 inline void permutation<N>::reset() {
 
-    for(register size_t i = 0; i < N; i++) m_idx[i] = i;
+    for(size_t i = 0; i < N; i++) m_idx[i] = i;
 }
 
 
 template<size_t N>
 inline void permutation<N>::apply_mask(const mask<N> &msk) {
 
-    register size_t i = 0;
+    size_t i = 0;
     while(i < N) {
         if(i != m_idx[i] && msk[i]) {
             permute(i, m_idx[i]);
@@ -301,7 +301,7 @@ inline const size_t &permutation<N>::operator[](size_t i) const {
 template<size_t N>
 inline bool permutation<N>::is_identity() const {
 
-    for(register size_t i = 0; i < N; i++)
+    for(size_t i = 0; i < N; i++)
         if(m_idx[i] != i) return false;
     return true;
 }
@@ -311,7 +311,7 @@ template<size_t N>
 inline bool permutation<N>::equals(const permutation<N> &p) const {
 
     if(&p == this) return true;
-    for(register size_t i = 0; i < N; i++)
+    for(size_t i = 0; i < N; i++)
         if(m_idx[i] != p.m_idx[i]) return false;
     return true;
 }
@@ -321,7 +321,7 @@ template<size_t N> template<typename T>
 void permutation<N>::apply(sequence<N, T> &seq) const {
 
     sequence<N, T> buf(seq);
-    for(register size_t i = 0; i < N; i++) seq[i] = buf[m_idx[i]];
+    for(size_t i = 0; i < N; i++) seq[i] = buf[m_idx[i]];
 }
 
 
@@ -342,7 +342,7 @@ inline bool permutation<N>::operator!=(const permutation<N> &p) const {
 template<size_t N>
 inline bool permutation<N>::operator<(const permutation<N> &p) const {
 
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(m_idx[i] != p.m_idx[i]) return m_idx[i] < p.m_idx[i];
     }
     return false;

--- a/libtensor/core/permutation_generator.h
+++ b/libtensor/core/permutation_generator.h
@@ -67,7 +67,7 @@ template<size_t N>
 permutation_generator<N>::permutation_generator() :
     m_map(0), m_p(0), m_done(false), m_n(N) {
 
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         m_map[i] = i;
         m_d[i] = true;
     }
@@ -78,8 +78,8 @@ template<size_t N>
 permutation_generator<N>::permutation_generator(const mask<N> &msk) :
     m_map(N), m_p(0), m_done(false) {
 
-    register size_t j = 0;
-    for (register size_t i = 0; i < N; i++) {
+    size_t j = 0;
+    for (size_t i = 0; i < N; i++) {
         if (! msk[i]) m_map[j++] = i;
         m_d[i] = true;
     }
@@ -94,7 +94,7 @@ bool permutation_generator<N>::next() {
 
     if (m_done) return false;
 
-    register size_t i = m_n - 1, k = 0;
+    size_t i = m_n - 1, k = 0;
     for (; i > 0; i--) {
         if (m_d[i]) { m_p[i]++; } else { m_p[i]--; }
         if (m_p[i] == (i + 1)) {

--- a/libtensor/core/sequence_generator.h
+++ b/libtensor/core/sequence_generator.h
@@ -51,7 +51,7 @@ public:
 
         if (m_done) return false;
 
-        register size_t j = 1;
+        size_t j = 1;
         for (; j < m_seq.size(); j++) {
             if (m_seq[j] - m_seq[j - 1] > 1) break;
         }
@@ -64,7 +64,7 @@ public:
             return false;
         }
 
-        for (register size_t i = 0; i < j; i++) m_seq[i] = i;
+        for (size_t i = 0; i < j; i++) m_seq[i] = i;
         return true;
     }
 

--- a/libtensor/core/split_points.h
+++ b/libtensor/core/split_points.h
@@ -20,7 +20,7 @@ public:
     bool add(size_t pos);
     bool equals(const split_points &sp) const;
     size_t get_num_points() const;
-    size_t operator[](size_t i) const throw(out_of_bounds);
+    size_t operator[](size_t i) const;
 };
 
 
@@ -63,7 +63,7 @@ inline size_t split_points::get_num_points() const {
 }
 
 
-inline size_t split_points::operator[](size_t i) const throw(out_of_bounds) {
+inline size_t split_points::operator[](size_t i) const {
 
 #ifdef LIBTENSOR_DEBUG
     if(i >= m_points.size()) {

--- a/libtensor/core/split_points.h
+++ b/libtensor/core/split_points.h
@@ -51,7 +51,7 @@ inline bool split_points::equals(const split_points &sp) const {
 
     size_t sz = m_points.size();
     if(sp.m_points.size() != sz) return false;
-    for(register size_t i = 0; i < sz; i++)
+    for(size_t i = 0; i < sz; i++)
         if(m_points[i] != sp.m_points[i]) return false;
     return true;
 }

--- a/libtensor/core/symmetry_element_set.h
+++ b/libtensor/core/symmetry_element_set.h
@@ -141,7 +141,7 @@ public:
     }
 
 private:
-    void remove_all() throw();
+    void remove_all() noexcept;
 
 };
 
@@ -158,7 +158,7 @@ symmetry_element_set<N, T>::~symmetry_element_set() {
 
 
 template<size_t N, typename T>
-void symmetry_element_set<N, T>::remove_all() throw() {
+void symmetry_element_set<N, T>::remove_all() noexcept {
 
     for(iterator i = m_set.begin(); i != m_set.end(); i++) {
         delete *i;

--- a/libtensor/core/symmetry_element_set.h
+++ b/libtensor/core/symmetry_element_set.h
@@ -141,7 +141,7 @@ public:
     }
 
 private:
-    void remove_all() throw();
+    void remove_all();
 
 };
 
@@ -158,7 +158,7 @@ symmetry_element_set<N, T>::~symmetry_element_set() {
 
 
 template<size_t N, typename T>
-void symmetry_element_set<N, T>::remove_all() throw() {
+void symmetry_element_set<N, T>::remove_all() {
 
     for(iterator i = m_set.begin(); i != m_set.end(); i++) {
         delete *i;

--- a/libtensor/dense_tensor/impl/dense_tensor_impl.h
+++ b/libtensor/dense_tensor/impl/dense_tensor_impl.h
@@ -83,7 +83,7 @@ dense_tensor<N, T, Alloc>::on_req_open_session() {
 
     size_t sz = m_sessions.size();
 
-    for(register size_t i = 0; i < sz; i++) {
+    for(size_t i = 0; i < sz; i++) {
         if(m_sessions[i] == 0) {
             m_sessions[i] = 1;
             m_session_ptrcount[i] = 0;

--- a/libtensor/dense_tensor/impl/tod_apply_impl.h
+++ b/libtensor/dense_tensor/impl/tod_apply_impl.h
@@ -73,7 +73,7 @@ void tod_apply<N, Functor>::perform(
     const dimensions<N> &dimsb = tb.get_dims();
 
     sequence<N, size_t> seqa;
-    for(register size_t i = 0; i < N; i++) seqa[i] = i;
+    for(size_t i = 0; i < N; i++) seqa[i] = i;
     m_permb.apply(seqa);
 
 

--- a/libtensor/dense_tensor/impl/tod_copy_impl.h
+++ b/libtensor/dense_tensor/impl/tod_copy_impl.h
@@ -86,7 +86,7 @@ void tod_copy<N>::perform(bool zero, dense_tensor_wr_i<N, double> &tb) {
         const dimensions<N> &dimsb = tb.get_dims();
 
         sequence<N, size_t> seqa(0);
-        for(register size_t i = 0; i < N; i++) seqa[i] = i;
+        for(size_t i = 0; i < N; i++) seqa[i] = i;
         m_perm.apply(seqa);
 
         std::list< loop_list_node<1, 1> > loop_in, loop_out;

--- a/libtensor/dense_tensor/impl/tod_mult1_impl.h
+++ b/libtensor/dense_tensor/impl/tod_mult1_impl.h
@@ -66,7 +66,7 @@ void tod_mult1<N>::perform(bool zero, dense_tensor_wr_i<N, double> &ta) {
     const dimensions<N> &dimsb = m_tb.get_dims();
 
     sequence<N, size_t> mapb(0);
-    for(register size_t i = 0; i < N; i++) mapb[i] = i;
+    for(size_t i = 0; i < N; i++) mapb[i] = i;
     m_permb.apply(mapb);
 
     std::list< loop_list_node<1, 1> > loop_in, loop_out;

--- a/libtensor/dense_tensor/impl/tod_trace_impl.h
+++ b/libtensor/dense_tensor/impl/tod_trace_impl.h
@@ -43,7 +43,7 @@ double tod_trace<N>::calculate() {
         ca.req_prefetch();
 
         sequence<k_ordera, size_t> map(0);
-        for(register size_t i = 0; i < k_ordera; i++) map[i] = i;
+        for(size_t i = 0; i < k_ordera; i++) map[i] = i;
         permutation<k_ordera> pinv(m_perm, true);
         pinv.apply(map);
 
@@ -95,7 +95,7 @@ void tod_trace<N>::check_dims() {
     static const char *method = "check_dims()";
 
     sequence<k_ordera, size_t> map(0);
-    for(register size_t i = 0; i < k_ordera; i++) map[i] = i;
+    for(size_t i = 0; i < k_ordera; i++) map[i] = i;
     permutation<k_ordera> pinv(m_perm, true);
     pinv.apply(map);
 

--- a/libtensor/exception.C
+++ b/libtensor/exception.C
@@ -7,7 +7,7 @@ namespace libtensor {
 
 exception::exception(const char *ns, const char *clazz, const char *method,
     const char *file, unsigned int line, const char *type,
-    const char *message) throw() {
+    const char *message) noexcept {
 
     if(ns == NULL) m_ns[0] = '\0';
     else { strncpy(m_ns, ns, 128); m_ns[127] = '\0'; }
@@ -102,7 +102,7 @@ exception::exception(const char *ns, const char *clazz, const char *method,
 }
 
 
-exception::exception(const exception &e) throw() : m_bt(e.m_bt) {
+exception::exception(const exception &e) noexcept : m_bt(e.m_bt) {
 
     strcpy(m_ns, e.m_ns);
     strcpy(m_clazz, e.m_clazz);
@@ -115,7 +115,7 @@ exception::exception(const exception &e) throw() : m_bt(e.m_bt) {
 }
 
 
-const char *exception::what() const throw() {
+const char *exception::what() const noexcept {
 
     return m_what;
 }

--- a/libtensor/exception.C
+++ b/libtensor/exception.C
@@ -115,7 +115,7 @@ exception::exception(const exception &e) : m_bt(e.m_bt) {
 }
 
 
-const char *exception::what() const {
+const char *exception::what() const noexcept {
 
     return m_what;
 }

--- a/libtensor/exception.C
+++ b/libtensor/exception.C
@@ -7,7 +7,7 @@ namespace libtensor {
 
 exception::exception(const char *ns, const char *clazz, const char *method,
     const char *file, unsigned int line, const char *type,
-    const char *message) throw() {
+    const char *message) {
 
     if(ns == NULL) m_ns[0] = '\0';
     else { strncpy(m_ns, ns, 128); m_ns[127] = '\0'; }
@@ -102,7 +102,7 @@ exception::exception(const char *ns, const char *clazz, const char *method,
 }
 
 
-exception::exception(const exception &e) throw() : m_bt(e.m_bt) {
+exception::exception(const exception &e) : m_bt(e.m_bt) {
 
     strcpy(m_ns, e.m_ns);
     strcpy(m_clazz, e.m_clazz);
@@ -115,7 +115,7 @@ exception::exception(const exception &e) throw() : m_bt(e.m_bt) {
 }
 
 
-const char *exception::what() const throw() {
+const char *exception::what() const {
 
     return m_what;
 }

--- a/libtensor/exception.h
+++ b/libtensor/exception.h
@@ -56,15 +56,15 @@ public:
      **/
     exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *type,
-        const char *message) throw();
+        const char *message) noexcept;
 
     /** \brief Copy constructor
      **/
-    exception(const exception &e) throw();
+    exception(const exception &e) noexcept;
 
     /** \brief Virtual destructor
      **/
-    virtual ~exception() throw() { };
+    virtual ~exception() noexcept { };
 
     //@}
 
@@ -74,7 +74,7 @@ public:
 
     /** \brief Returns the cause of the exception (message)
      **/
-    virtual const char *what() const throw();
+    virtual const char *what() const noexcept;
 
     //@}
 
@@ -87,7 +87,7 @@ public:
 
     /** \brief Clones the exception
      **/
-    virtual libutil::rethrowable_i *clone() const throw() = 0;
+    virtual libutil::rethrowable_i *clone() const noexcept = 0;
 
     /** \brief Throws itself
      **/
@@ -101,12 +101,12 @@ class exception_base : public exception {
 public:
     exception_base(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *type,
-        const char *message) throw() : exception(ns, clazz, method,
+        const char *message) noexcept : exception(ns, clazz, method,
         file, line, type, message) { }
 
-    virtual ~exception_base() throw() { }
+    virtual ~exception_base() noexcept { }
 
-    virtual libutil::rethrowable_i *clone() const throw() {
+    virtual libutil::rethrowable_i *clone() const noexcept {
         return new T(dynamic_cast<const T&>(*this));
     }
 
@@ -130,13 +130,13 @@ public:
      **/
     generic_exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
+        noexcept
         : exception_base<generic_exception>(ns, clazz, method,
             file, line, "generic_exception", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~generic_exception() throw() { };
+    virtual ~generic_exception() noexcept { };
 
     //@}
 
@@ -156,13 +156,13 @@ public:
      **/
     bad_parameter(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
+        noexcept
         : exception_base<bad_parameter>(ns, clazz, method, file, line,
             "bad_parameter", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_parameter() throw() { };
+    virtual ~bad_parameter() noexcept { };
 
     //@}
 
@@ -182,13 +182,13 @@ public:
      **/
     block_not_found(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
+        noexcept
         : exception_base<block_not_found>(ns, clazz, method, file, line,
             "block_not_found", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~block_not_found() throw() { };
+    virtual ~block_not_found() noexcept { };
 
     //@}
 
@@ -209,13 +209,13 @@ public:
      **/
     immut_violation(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
+        noexcept
         : exception_base<immut_violation>(ns, clazz, method, file, line,
             "immut_violation", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~immut_violation() throw() { };
+    virtual ~immut_violation() noexcept { };
 
     //@}
 };
@@ -235,13 +235,13 @@ public:
      **/
     out_of_memory(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
+        noexcept
         : exception_base<out_of_memory>(ns, clazz, method, file, line,
             "out_of_memory", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~out_of_memory() throw() { };
+    virtual ~out_of_memory() noexcept { };
 
     //@}
 };
@@ -260,13 +260,13 @@ public:
      **/
     symmetry_violation(const char *ns, const char *clazz,
         const char *method, const char *file, unsigned int line,
-        const char *message) throw()
+        const char *message) noexcept
         : exception_base<symmetry_violation>(ns, clazz, method,
             file, line, "symmetry_violation", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~symmetry_violation() throw() { };
+    virtual ~symmetry_violation() noexcept { };
 
     //@}
 };

--- a/libtensor/exception.h
+++ b/libtensor/exception.h
@@ -74,7 +74,7 @@ public:
 
     /** \brief Returns the cause of the exception (message)
      **/
-    virtual const char *what() const;
+    virtual const char *what() const noexcept;
 
     //@}
 

--- a/libtensor/exception.h
+++ b/libtensor/exception.h
@@ -56,15 +56,15 @@ public:
      **/
     exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *type,
-        const char *message) throw();
+        const char *message);
 
     /** \brief Copy constructor
      **/
-    exception(const exception &e) throw();
+    exception(const exception &e);
 
     /** \brief Virtual destructor
      **/
-    virtual ~exception() throw() { };
+    virtual ~exception() { };
 
     //@}
 
@@ -74,7 +74,7 @@ public:
 
     /** \brief Returns the cause of the exception (message)
      **/
-    virtual const char *what() const throw();
+    virtual const char *what() const;
 
     //@}
 
@@ -87,7 +87,7 @@ public:
 
     /** \brief Clones the exception
      **/
-    virtual libutil::rethrowable_i *clone() const throw() = 0;
+    virtual libutil::rethrowable_i *clone() const = 0;
 
     /** \brief Throws itself
      **/
@@ -101,12 +101,12 @@ class exception_base : public exception {
 public:
     exception_base(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *type,
-        const char *message) throw() : exception(ns, clazz, method,
+        const char *message) : exception(ns, clazz, method,
         file, line, type, message) { }
 
-    virtual ~exception_base() throw() { }
+    virtual ~exception_base() { }
 
-    virtual libutil::rethrowable_i *clone() const throw() {
+    virtual libutil::rethrowable_i *clone() const {
         return new T(dynamic_cast<const T&>(*this));
     }
 
@@ -130,13 +130,12 @@ public:
      **/
     generic_exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
         : exception_base<generic_exception>(ns, clazz, method,
             file, line, "generic_exception", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~generic_exception() throw() { };
+    virtual ~generic_exception() { };
 
     //@}
 
@@ -156,13 +155,12 @@ public:
      **/
     bad_parameter(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
         : exception_base<bad_parameter>(ns, clazz, method, file, line,
             "bad_parameter", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_parameter() throw() { };
+    virtual ~bad_parameter() { };
 
     //@}
 
@@ -182,13 +180,12 @@ public:
      **/
     block_not_found(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
         : exception_base<block_not_found>(ns, clazz, method, file, line,
             "block_not_found", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~block_not_found() throw() { };
+    virtual ~block_not_found() { };
 
     //@}
 
@@ -209,13 +206,12 @@ public:
      **/
     immut_violation(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
         : exception_base<immut_violation>(ns, clazz, method, file, line,
             "immut_violation", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~immut_violation() throw() { };
+    virtual ~immut_violation() { };
 
     //@}
 };
@@ -235,13 +231,12 @@ public:
      **/
     out_of_memory(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw()
         : exception_base<out_of_memory>(ns, clazz, method, file, line,
             "out_of_memory", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~out_of_memory() throw() { };
+    virtual ~out_of_memory() { };
 
     //@}
 };
@@ -260,13 +255,13 @@ public:
      **/
     symmetry_violation(const char *ns, const char *clazz,
         const char *method, const char *file, unsigned int line,
-        const char *message) throw()
+        const char *message)
         : exception_base<symmetry_violation>(ns, clazz, method,
             file, line, "symmetry_violation", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~symmetry_violation() throw() { };
+    virtual ~symmetry_violation() { };
 
     //@}
 };

--- a/libtensor/expr/bispace/bispace_exception.h
+++ b/libtensor/expr/bispace/bispace_exception.h
@@ -19,14 +19,14 @@ public:
     /** \brief Creates an exception
      **/
     bispace_exception(const char *clazz, const char *method,
-        const char *file, unsigned int line, const char *message) throw() :
+        const char *file, unsigned int line, const char *message) noexcept :
         exception_base<bispace_exception>("libtensor::expr", clazz, method,
             file, line, "bispace_exception", message)
     { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~bispace_exception() throw() { }
+    virtual ~bispace_exception() noexcept { }
 
     //@}
 

--- a/libtensor/expr/bispace/bispace_exception.h
+++ b/libtensor/expr/bispace/bispace_exception.h
@@ -19,14 +19,14 @@ public:
     /** \brief Creates an exception
      **/
     bispace_exception(const char *clazz, const char *method,
-        const char *file, unsigned int line, const char *message) throw() :
+        const char *file, unsigned int line, const char *message) :
         exception_base<bispace_exception>("libtensor::expr", clazz, method,
             file, line, "bispace_exception", message)
     { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~bispace_exception() throw() { }
+    virtual ~bispace_exception() { }
 
     //@}
 

--- a/libtensor/expr/eval/eval_exception.h
+++ b/libtensor/expr/eval/eval_exception.h
@@ -20,13 +20,13 @@ public:
      **/
     eval_exception(const char *file, unsigned int line, const char *ns,
         const char *clazz, const char *method, const char *message)
-        throw() :
+        noexcept :
         exception_base<eval_exception>(ns, clazz, method, file, line,
             "eval_exception", message) { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~eval_exception() throw() { }
+    virtual ~eval_exception() noexcept { }
 
     //@}
 };

--- a/libtensor/expr/eval/eval_exception.h
+++ b/libtensor/expr/eval/eval_exception.h
@@ -20,13 +20,13 @@ public:
      **/
     eval_exception(const char *file, unsigned int line, const char *ns,
         const char *clazz, const char *method, const char *message)
-        throw() :
+        :
         exception_base<eval_exception>(ns, clazz, method, file, line,
             "eval_exception", message) { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~eval_exception() throw() { }
+    virtual ~eval_exception() { }
 
     //@}
 };

--- a/libtensor/expr/expr_exception.h
+++ b/libtensor/expr/expr_exception.h
@@ -20,13 +20,13 @@ public:
      **/
     expr_exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw() :
+        noexcept :
         exception_base<expr_exception>(ns, clazz, method, file, line,
             "expr_exception", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~expr_exception() throw() { };
+    virtual ~expr_exception() noexcept { };
 
     //@}
 };

--- a/libtensor/expr/expr_exception.h
+++ b/libtensor/expr/expr_exception.h
@@ -20,13 +20,13 @@ public:
      **/
     expr_exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw() :
+        :
         exception_base<expr_exception>(ns, clazz, method, file, line,
             "expr_exception", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~expr_exception() throw() { };
+    virtual ~expr_exception() { };
 
     //@}
 };

--- a/libtensor/expr/iface/label.h
+++ b/libtensor/expr/iface/label.h
@@ -37,7 +37,7 @@ public:
     /** \brief Returns the %index of a %letter in the expression
         \throw exception If the expression doesn't contain the %letter.
      **/
-    size_t index_of(const letter &let) const throw(exception) {
+    size_t index_of(const letter &let) const {
         if(&m_let == &let) return N - 1;
         return m_expr.index_of(let);
     }
@@ -45,7 +45,7 @@ public:
     /** \brief Returns the %letter at a given position
         \throw out_of_bounds If the %index is out of bounds.
      **/
-    const letter &letter_at(size_t i) const throw(out_of_bounds) {
+    const letter &letter_at(size_t i) const {
         if(i == N - 1) return m_let;
         return m_expr.letter_at(i);
     }
@@ -56,7 +56,7 @@ public:
         \param e2 Second expression.
      **/
     permutation<N> permutation_of(const label<N> &expr) const
-        throw(exception) {
+        {
 
         const letter *seq1[N], *seq2[N];
         unfold(seq1);
@@ -95,7 +95,7 @@ public:
     /** \brief Returns the %index of a %letter in the expression
         \throw exception If the expression doesn't contain the %letter.
      **/
-    size_t index_of(const letter &let) const throw(exception) {
+    size_t index_of(const letter &let) const {
         if(&m_let != &let) {
             throw_exc("letter_expr<1>", "index_of()",
                 "Expression doesn't contain the letter.");
@@ -106,7 +106,7 @@ public:
     /** \brief Returns the %letter at a given position
         \throw exception If the %index is out of bounds.
      **/
-    const letter &letter_at(size_t i) const throw(out_of_bounds) {
+    const letter &letter_at(size_t i) const {
         if(i != 0) {
             throw out_of_bounds(g_ns, "letter_expr<1>",
                 "letter_at(size_t)", __FILE__, __LINE__,

--- a/libtensor/gen_block_tensor/addition_schedule.h
+++ b/libtensor/gen_block_tensor/addition_schedule.h
@@ -103,7 +103,7 @@ public:
 private:
     /** \brief Removes all elements from the schedule
      **/
-    void clear_schedule() throw();
+    void clear_schedule() noexcept;
 
 };
 

--- a/libtensor/gen_block_tensor/addition_schedule.h
+++ b/libtensor/gen_block_tensor/addition_schedule.h
@@ -103,7 +103,7 @@ public:
 private:
     /** \brief Removes all elements from the schedule
      **/
-    void clear_schedule() throw();
+    void clear_schedule();
 
 };
 

--- a/libtensor/gen_block_tensor/block_stream_exception.h
+++ b/libtensor/gen_block_tensor/block_stream_exception.h
@@ -21,13 +21,13 @@ public:
      **/
     block_stream_exception(const char *ns, const char *clazz,
         const char *method, const char *file, unsigned int line,
-        const char *message) throw() :
+        const char *message) noexcept :
         exception_base<block_stream_exception>(ns, clazz, method, file, line,
             "block_stream_exception", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~block_stream_exception() throw() { };
+    virtual ~block_stream_exception() noexcept { };
 
     //@}
 

--- a/libtensor/gen_block_tensor/block_stream_exception.h
+++ b/libtensor/gen_block_tensor/block_stream_exception.h
@@ -21,13 +21,13 @@ public:
      **/
     block_stream_exception(const char *ns, const char *clazz,
         const char *method, const char *file, unsigned int line,
-        const char *message) throw() :
+        const char *message) :
         exception_base<block_stream_exception>(ns, clazz, method, file, line,
             "block_stream_exception", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~block_stream_exception() throw() { };
+    virtual ~block_stream_exception() { };
 
     //@}
 

--- a/libtensor/gen_block_tensor/impl/addition_schedule_impl.h
+++ b/libtensor/gen_block_tensor/impl/addition_schedule_impl.h
@@ -40,7 +40,7 @@ addition_schedule<N, Traits>::addition_schedule(
 
     mask<N + N> msk;
     sequence<N + N, size_t> seq(0);
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         msk[i] = msk[i + N] = true;
         seq[i] = seq[i + N] = i;
     }

--- a/libtensor/gen_block_tensor/impl/addition_schedule_impl.h
+++ b/libtensor/gen_block_tensor/impl/addition_schedule_impl.h
@@ -415,7 +415,7 @@ void addition_schedule<N, Traits>::build(
 
 
 template<size_t N, typename Traits>
-void addition_schedule<N, Traits>::clear_schedule() throw() {
+void addition_schedule<N, Traits>::clear_schedule() {
 
     for(typename schedule_type::iterator i = m_sch.begin();
         i != m_sch.end(); ++i) delete *i;

--- a/libtensor/gen_block_tensor/impl/addition_schedule_impl.h
+++ b/libtensor/gen_block_tensor/impl/addition_schedule_impl.h
@@ -415,7 +415,7 @@ void addition_schedule<N, Traits>::build(
 
 
 template<size_t N, typename Traits>
-void addition_schedule<N, Traits>::clear_schedule() throw() {
+void addition_schedule<N, Traits>::clear_schedule() noexcept {
 
     for(typename schedule_type::iterator i = m_sch.begin();
         i != m_sch.end(); ++i) delete *i;

--- a/libtensor/gen_block_tensor/impl/gen_bto_diag_impl.h
+++ b/libtensor/gen_block_tensor/impl/gen_bto_diag_impl.h
@@ -195,12 +195,12 @@ void gen_bto_diag<N, M, Traits, Timed>::compute_block_untimed(
 
     sequence<NB, size_t> seq1(0), seq2(0);
     sequence<NB, size_t> seqb1(0), seqb2(0);
-    for(register size_t i = 0, j1 = 0, j2 = 0; i < NA; i++) {
+    for(size_t i = 0, j1 = 0, j2 = 0; i < NA; i++) {
         if(m1[i] == 0) seq1[j1++] = map1[i];
         if(m2[i] == 0) seq2[j2++] = map2[i];
     }
     mask<NB + 1> b1, b2;
-    for(register size_t i = 0, j1 = 0, j2 = 0; i < NB; i++) {
+    for(size_t i = 0, j1 = 0, j2 = 0; i < NB; i++) {
         if (m1[i] != 0 && !b1[m1[i]]) {
             seqb1[i] = NB + m1[i]; b1[m1[i]] = true;
         }

--- a/libtensor/gen_block_tensor/impl/gen_bto_ewmult2_impl.h
+++ b/libtensor/gen_block_tensor/impl/gen_bto_ewmult2_impl.h
@@ -312,42 +312,42 @@ void gen_bto_ewmult2<N, M, K, Traits, Timed>::make_symc() {
     sequence<NA, size_t> seq2a;
     sequence<NB, size_t> seq2b;
     sequence<NC, size_t> seq2c;
-    for (register size_t i = 0; i < NA; i++) seq2a[i] = i;
+    for (size_t i = 0; i < NA; i++) seq2a[i] = i;
     m_tra.get_perm().apply(seq2a);
-    for (register size_t i = 0, j = NA; i < NB; i++, j++)
+    for (size_t i = 0, j = NA; i < NB; i++, j++)
         seq2b[i] = j;
     m_trb.get_perm().apply(seq2b);
-    for (register size_t i = 0; i < NC; i++) seq2c[i] = i;
+    for (size_t i = 0; i < NC; i++) seq2c[i] = i;
     m_trc.get_perm().apply(seq2c);
 
     sequence<NC, size_t> seq2imx, seqx;
     sequence<NA + NB, size_t> seq1im, seq2im, seq;
-    for (register size_t i = 0; i != N; i++) {
+    for (size_t i = 0; i != N; i++) {
         seq1im[i] = i;
         seq2imx[i] = seq2a[i];
     }
-    for (register size_t i = 0, j = N; i != M; i++, j++) {
+    for (size_t i = 0, j = N; i != M; i++, j++) {
         seq1im[j] = j;
         seq2imx[j] = seq2b[i];
     }
 
     mask<NC> mskx;
     mask<NA + NB> msk;
-    for (register size_t i = 0, j = N + M; i != K; i++, j++) {
+    for (size_t i = 0, j = N + M; i != K; i++, j++) {
         seq1im[j] = j;
         seq2imx[j] = seq2a[i + N];
         mskx[j] = true;
         seqx[j] = i;
     }
 
-    for (register size_t i = 0, j = NC; i != K; i++, j++) {
+    for (size_t i = 0, j = NC; i != K; i++, j++) {
         seq1im[j] = j;
         seq2im[j] = seq2b[i + M];
         msk[j] = true;
         seq[j] = i;
     }
 
-    for (register size_t i = 0; i != NC; i++) {
+    for (size_t i = 0; i != NC; i++) {
         seq2im[i] = seq2imx[seq2c[i]];
         seq[i] = seqx[seq2c[i]];
         msk[i] = mskx[seq2c[i]];

--- a/libtensor/gen_block_tensor/impl/gen_bto_extract_impl.h
+++ b/libtensor/gen_block_tensor/impl/gen_bto_extract_impl.h
@@ -101,7 +101,7 @@ gen_bto_extract<N, M, Traits, Timed>::gen_bto_extract(
 
     sequence<NA, size_t> seq(0);
     mask<NA> invmsk;
-    for (register size_t i = 0, j = 0; i < NA; i++) {
+    for (size_t i = 0, j = 0; i < NA; i++) {
         invmsk[i] = !m_msk[i];
         if (invmsk[i]) seq[i] = j++;
     }
@@ -198,9 +198,9 @@ void gen_bto_extract<N, M, Traits, Timed>::compute_block_untimed(
 
     sequence<NA, size_t> seqa1(0), seqa2(0);
     sequence<NB, size_t> seqb1(0), seqb2(0);
-    for(register size_t i = 0; i < NA; i++) seqa2[i] = seqa1[i] = i;
+    for(size_t i = 0; i < NA; i++) seqa2[i] = seqa1[i] = i;
     tra.get_perm().apply(seqa2);
-    for(register size_t i = 0, j1 = 0, j2 = 0; i < NA; i++) {
+    for(size_t i = 0, j1 = 0, j2 = 0; i < NA; i++) {
         if(msk1[i]) seqb1[j1++] = seqa1[i];
         if(msk2[i]) seqb2[j2++] = seqa2[i];
     }
@@ -283,7 +283,7 @@ block_index_space<N - M> gen_bto_extract<N, M, Traits, Timed>::mk_bis(
             if(bis.get_type(map[k]) == typ) msk_typ[k] = true;
         }
         size_t npts = splits.get_num_points();
-        for(register size_t k = 0; k < npts; k++) {
+        for(size_t k = 0; k < npts; k++) {
             obis.split(msk_typ, splits[k]);
         }
         msk_done |= msk_typ;

--- a/libtensor/gen_block_tensor/impl/gen_bto_mult1_impl.h
+++ b/libtensor/gen_block_tensor/impl/gen_bto_mult1_impl.h
@@ -150,7 +150,7 @@ void gen_bto_mult1<N, Traits, Timed>::perform(
                 cb.req_const_symmetry(), pbb.get_perm()).perform(symx);
             mask<N + N> msk;
             sequence<N + N, size_t> seq;
-            for(register size_t i = 0; i < N; i++) {
+            for(size_t i = 0; i < N; i++) {
                 msk[i] = msk[i + N] = true;
                 seq[i] = seq[i + N] = i;
             }

--- a/libtensor/gen_block_tensor/impl/gen_bto_mult_impl.h
+++ b/libtensor/gen_block_tensor/impl/gen_bto_mult_impl.h
@@ -129,7 +129,7 @@ gen_bto_mult<N, Traits, Timed>::gen_bto_mult(
             cb.req_const_symmetry(), pbb.get_perm()).perform(symx);
     mask<N + N> msk;
     sequence<N + N, size_t> seq;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         msk[i] = msk[i + N] = true;
         seq[i] = seq[i + N] = i;
     }

--- a/libtensor/gen_block_tensor/impl/gen_bto_symmetrize2_impl.h
+++ b/libtensor/gen_block_tensor/impl/gen_bto_symmetrize2_impl.h
@@ -133,11 +133,11 @@ template<size_t N, typename Traits, typename Timed>
 void gen_bto_symmetrize2<N, Traits, Timed>::make_symmetry() {
 
     sequence<N, size_t> seq2(0), idxgrp(0), symidx(0);
-    for(register size_t i = 0; i < N; i++) seq2[i] = i;
+    for(size_t i = 0; i < N; i++) seq2[i] = i;
     m_perm1.apply(seq2);
 
     size_t idx = 1;
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(seq2[i] <= i) continue;
         idxgrp[i] = 1;
         idxgrp[seq2[i]] = 2;

--- a/libtensor/gen_block_tensor/impl/gen_bto_trace_impl.h
+++ b/libtensor/gen_block_tensor/impl/gen_bto_trace_impl.h
@@ -167,7 +167,7 @@ void gen_bto_trace_in_orbit_task<N, Traits, Timed>::perform() {
             ia.permute(m_perm);
 
             bool skip = false;
-            for(register size_t i = 0; i < N; i++) {
+            for(size_t i = 0; i < N; i++) {
                 if(ia[i] != ia[N + i]) {
                     skip = true;
                     break;

--- a/libtensor/kernels/overflow.h
+++ b/libtensor/kernels/overflow.h
@@ -17,13 +17,13 @@ public:
     /** \brief Creates an exception
      **/
     overflow(const char *ns, const char *clazz, const char *method,
-            const char *file, unsigned int line, const char *message) throw() :
+            const char *file, unsigned int line, const char *message) noexcept :
             exception_base<overflow>(ns, clazz, method, file, line,
                     "overflow", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~overflow() throw() { };
+    virtual ~overflow() noexcept { };
 
     //@}
 };

--- a/libtensor/kernels/overflow.h
+++ b/libtensor/kernels/overflow.h
@@ -17,13 +17,13 @@ public:
     /** \brief Creates an exception
      **/
     overflow(const char *ns, const char *clazz, const char *method,
-            const char *file, unsigned int line, const char *message) throw() :
+            const char *file, unsigned int line, const char *message):
             exception_base<overflow>(ns, clazz, method, file, line,
                     "overflow", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~overflow() throw() { };
+    virtual ~overflow() { };
 
     //@}
 };

--- a/libtensor/not_implemented.h
+++ b/libtensor/not_implemented.h
@@ -18,13 +18,13 @@ public:
     /** \brief Creates an exception
      **/
     not_implemented(const char *ns, const char *clazz, const char *method,
-        const char *file, unsigned int line) throw() :
+        const char *file, unsigned int line) noexcept :
         exception_base<not_implemented>(ns, clazz, method, file, line,
             "not_implemented", "NIY") { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~not_implemented() throw() { };
+    virtual ~not_implemented() noexcept { };
 
     //@}
 };

--- a/libtensor/not_implemented.h
+++ b/libtensor/not_implemented.h
@@ -18,13 +18,13 @@ public:
     /** \brief Creates an exception
      **/
     not_implemented(const char *ns, const char *clazz, const char *method,
-        const char *file, unsigned int line) throw() :
+        const char *file, unsigned int line) :
         exception_base<not_implemented>(ns, clazz, method, file, line,
             "not_implemented", "NIY") { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~not_implemented() throw() { };
+    virtual ~not_implemented() { };
 
     //@}
 };

--- a/libtensor/symmetry/bad_symmetry.h
+++ b/libtensor/symmetry/bad_symmetry.h
@@ -19,13 +19,13 @@ public:
      **/
     bad_symmetry(const char *ns, const char *clazz, const char *method,
             const char *file, unsigned int line, const char *message)
-    throw() :
+    noexcept :
         exception_base<bad_symmetry>(ns, clazz, method, file, line,
                 "bad_symmetry", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_symmetry() throw() { };
+    virtual ~bad_symmetry() noexcept { };
 
     //@}
 };

--- a/libtensor/symmetry/bad_symmetry.h
+++ b/libtensor/symmetry/bad_symmetry.h
@@ -18,14 +18,13 @@ public:
     /** \brief Creates an exception
      **/
     bad_symmetry(const char *ns, const char *clazz, const char *method,
-            const char *file, unsigned int line, const char *message)
-    throw() :
+            const char *file, unsigned int line, const char *message) :
         exception_base<bad_symmetry>(ns, clazz, method, file, line,
                 "bad_symmetry", message) { };
 
     /** \brief Virtual destructor
      **/
-    virtual ~bad_symmetry() throw() { };
+    virtual ~bad_symmetry() { };
 
     //@}
 };

--- a/libtensor/symmetry/block_labeling.h
+++ b/libtensor/symmetry/block_labeling.h
@@ -101,15 +101,15 @@ public:
         \param type Dimension type.
         \throw bad_parameter If the dimension type is invalid.
      **/
-    size_t get_dim(size_t type) const throw(out_of_bounds);
+    size_t get_dim(size_t type) const;
 
     /** \brief Returns the label of a block of a dimension type.
         \param type Dimension type.
         \param pos Block position.
         \throw out_of_bounds If the dimension type is out of bounds.
      **/
-    label_t get_label(size_t type, size_t pos) const throw(out_of_bounds);
-    
+    label_t get_label(size_t type, size_t pos) const;
+
     //@}
 };
 
@@ -183,7 +183,7 @@ size_t block_labeling<N>::get_dim_type(size_t dim) const {
 
 template<size_t N>
 inline
-size_t block_labeling<N>::get_dim(size_t type) const throw(out_of_bounds) {
+size_t block_labeling<N>::get_dim(size_t type) const {
 
 #ifdef LIBTENSOR_DEBUG
     if (type > N || m_labels[type] == 0)
@@ -199,7 +199,7 @@ size_t block_labeling<N>::get_dim(size_t type) const throw(out_of_bounds) {
 template<size_t N>
 inline
 typename block_labeling<N>::label_t block_labeling<N>::get_label(size_t type,
-        size_t blk) const throw (out_of_bounds) {
+        size_t blk) const {
 
 #ifdef LIBTENSOR_DEBUG
     static const char *method = "get_label(size_t, size_t)";

--- a/libtensor/symmetry/block_labeling.h
+++ b/libtensor/symmetry/block_labeling.h
@@ -141,7 +141,7 @@ inline
 block_labeling<N>::block_labeling(const block_labeling<N> &bl) :
     m_bidims(bl.m_bidims), m_type(bl.m_type), m_labels(0) {
 
-    for (register size_t i = 0; i < N && bl.m_labels[i] != 0; i++) {
+    for (size_t i = 0; i < N && bl.m_labels[i] != 0; i++) {
 
         m_labels[i] = new blk_label_t(*(bl.m_labels[i]));
     }
@@ -152,7 +152,7 @@ template<size_t N>
 inline
 block_labeling<N>::~block_labeling() {
 
-    for (register size_t i = 0; i < N && m_labels[i] != 0; i++) {
+    for (size_t i = 0; i < N && m_labels[i] != 0; i++) {
         delete m_labels[i]; m_labels[i] = 0;
     }
 }

--- a/libtensor/symmetry/eval_sequence_list.h
+++ b/libtensor/symmetry/eval_sequence_list.h
@@ -84,7 +84,7 @@ size_t eval_sequence_list<N>::get_position(const eval_sequence_t &seq) const {
     for (; seqno < m_list.size(); seqno++) {
         const eval_sequence_t &ref = m_list[seqno];
 
-        register size_t i = 0;
+        size_t i = 0;
         for (; i < N; i++) {
             if (seq[i] != ref[i]) break;
         }

--- a/libtensor/symmetry/inst/block_labeling_impl.h
+++ b/libtensor/symmetry/inst/block_labeling_impl.h
@@ -13,14 +13,14 @@ block_labeling<N>::block_labeling(const dimensions<N> &bidims) :
     m_bidims(bidims), m_type((size_t) -1), m_labels(0) {
 
     size_t cur_type = 0;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (m_type[i] != (size_t) -1) continue;
 
         m_type[i] = cur_type;
         m_labels[cur_type] =
                 new blk_label_t(m_bidims[i], product_table_i::k_invalid);
 
-        for (register size_t j = i + 1; j < N; j++) {
+        for (size_t j = i + 1; j < N; j++) {
 
             if (m_bidims[i] == m_bidims[j]) m_type[j] = cur_type;
         }
@@ -34,7 +34,7 @@ void block_labeling<N>::assign(const mask<N> &msk, size_t blk, label_t l) {
 
     static const char *method = "assign(const mask<N> &, size_t, label_t)";
 
-    register size_t i = 0;
+    size_t i = 0;
     for (; i < N; i++)  if (msk[i]) break;
     if (i == N) return; // mask has no true component
 
@@ -47,7 +47,7 @@ void block_labeling<N>::assign(const mask<N> &msk, size_t blk, label_t l) {
     }
 
     // Test if all masked indexes are of the same type
-    for (register size_t j = i + 1; j < N; j++) {
+    for (size_t j = i + 1; j < N; j++) {
         if (! msk[j]) continue;
         if (m_type[j] == type) continue;
 
@@ -94,7 +94,7 @@ void block_labeling<N>::match() {
     }
 
     size_t cur_type = 0;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
 
         size_t itype = types[i];
         if (labels[itype] == 0) continue;
@@ -136,7 +136,7 @@ void block_labeling<N>::match() {
 template<size_t N>
 void block_labeling<N>::clear() {
 
-    for (register size_t i = 0; i < N && m_labels[i] != 0; i++) {
+    for (size_t i = 0; i < N && m_labels[i] != 0; i++) {
         blk_label_t &lg = *(m_labels[i]);
         for (size_t j = 0; j < lg.size(); j++)
             lg[j] = product_table_i::k_invalid;
@@ -151,10 +151,10 @@ bool operator==(const block_labeling<N> &a, const block_labeling<N> &b) {
 
     if (a.get_block_index_dims() != b.get_block_index_dims()) return false;
 
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         size_t ta = a.get_dim_type(i), tb = b.get_dim_type(i);
 
-        for (register size_t j = 0; j < a.get_dim(ta); j++) {
+        for (size_t j = 0; j < a.get_dim(ta); j++) {
             if (a.get_label(ta, j) != b.get_label(tb, j)) return false;
         }
     }
@@ -172,14 +172,14 @@ void transfer_labeling(const block_labeling<N> &from,
             "const sequence<N> &, block_labeling<M> &)";
 
 #ifdef LIBTENSOR_DEBUG
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (map[i] == (size_t) -1) continue;
         if (map[i] >= M) {
             throw bad_symmetry(g_ns, "", method,
                     __FILE__, __LINE__, "Invalid map.");
         }
 
-        for (register size_t j = i + 1; j < N; j++) {
+        for (size_t j = i + 1; j < N; j++) {
             if (map[i] == map[j])
                 throw bad_symmetry(g_ns, "", method,
                         __FILE__, __LINE__, "Invalid map.");
@@ -188,14 +188,14 @@ void transfer_labeling(const block_labeling<N> &from,
 #endif
 
     mask<N> done;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (map[i] == (size_t) -1 || done[i]) continue;
 
         size_t typei = from.get_dim_type(i);
         mask<M> m; m[map[i]] = true;
 
         // Find dimensions that can be transferred together with i.
-        for (register size_t j = i + 1; j < N; j++) {
+        for (size_t j = i + 1; j < N; j++) {
             if (done[j]) continue;
             if (map[j] == (size_t) -1) { done[j] = true; continue; }
             if (from.get_dim_type(j) != typei) continue;

--- a/libtensor/symmetry/inst/combine_label.h
+++ b/libtensor/symmetry/inst/combine_label.h
@@ -26,7 +26,7 @@ private:
 public:
     combine_label(const se_label<N, T> &el);
 
-    void add(const se_label<N, T> &el) throw(bad_parameter);
+    void add(const se_label<N, T> &el);
 
     const std::string &get_table_id() const { return m_table_id; }
     const block_labeling<N> &get_labeling() const { return m_blk_labels; }

--- a/libtensor/symmetry/inst/combine_label_impl.h
+++ b/libtensor/symmetry/inst/combine_label_impl.h
@@ -19,7 +19,7 @@ combine_label<N, T>::combine_label(const se_label<N, T> &el) :
 
 
 template<size_t N, typename T>
-void combine_label<N, T>::add(const se_label<N, T> &el) throw(bad_parameter) {
+void combine_label<N, T>::add(const se_label<N, T> &el) {
 
     static const char *method = "add(const se_label<N, T> &)";
 

--- a/libtensor/symmetry/inst/combine_part_impl.h
+++ b/libtensor/symmetry/inst/combine_part_impl.h
@@ -42,7 +42,7 @@ void combine_part<N, T>::perform(se_t &el) {
 
             // Get the respective partition index in current se_part<N, T>
             index<N> ix1;
-            for (register size_t i = 0; i < N; i++) {
+            for (size_t i = 0; i < N; i++) {
                 if (pdims[i] != 1) { ix1[i] = i1[i]; }
             }
 

--- a/libtensor/symmetry/inst/er_merge_impl.h
+++ b/libtensor/symmetry/inst/er_merge_impl.h
@@ -53,12 +53,12 @@ void er_merge<N, M>::perform(evaluation_rule<M> &to) const {
         const sequence<N, size_t> &seq1 = slist1[i];
         sequence<M, size_t> seq2(0);
 
-        for (register size_t j = 0; j < N; j++) {
+        for (size_t j = 0; j < N; j++) {
             seq2[m_mmap[j]] += seq1[j];
         }
 
         size_t nidx = 0;
-        for (register size_t j = 0; j < M; j++) {
+        for (size_t j = 0; j < M; j++) {
             if (m_smsk[j]) seq2[j] = seq2[j] % 2;
 
             nidx += seq2[j];

--- a/libtensor/symmetry/inst/er_optimize_impl.h
+++ b/libtensor/symmetry/inst/er_optimize_impl.h
@@ -66,7 +66,7 @@ void er_optimize<N>::perform(evaluation_rule<N> &to) const {
 
         if (m_mergable) {
             size_t nidx = 0, nidx0 = 0;
-            for (register size_t j = 0; j < N; j++) {
+            for (size_t j = 0; j < N; j++) {
                 nidx0 += seq[j]; nidx += (seq[j] % 2);
             }
             if (nidx != 0) {
@@ -74,7 +74,7 @@ void er_optimize<N>::perform(evaluation_rule<N> &to) const {
                 else {
                     new_seq.push_back(sequence<N, size_t>());
                     sequence<N, size_t> &seq2 = new_seq.back();
-                    for (register size_t j = 0; j < N; j++)
+                    for (size_t j = 0; j < N; j++)
                         seq2[j] = seq[j] % 2;
                     seq_ptr[i] = &seq2;
                 }
@@ -82,7 +82,7 @@ void er_optimize<N>::perform(evaluation_rule<N> &to) const {
         }
         else {
             size_t nidx = 0;
-            for (register size_t j = 0; j < N; j++) nidx += seq[j];
+            for (size_t j = 0; j < N; j++) nidx += seq[j];
             if (nidx != 0) seq_ptr[i] = &seq;
         }
     }

--- a/libtensor/symmetry/inst/permutation_group_impl.h
+++ b/libtensor/symmetry/inst/permutation_group_impl.h
@@ -102,8 +102,8 @@ void permutation_group<N, T>::project_down(const mask<N> &msk,
     static const char *method =
             "project_down<M>(const mask<N>&, permutation_group<M, T>&)";
 
-    register size_t m = 0;
-    for(register size_t i = 0; i < N; i++) if(msk[i]) m++;
+    size_t m = 0;
+    for(size_t i = 0; i < N; i++) if(msk[i]) m++;
     if(m != M) {
         throw bad_parameter(g_ns, k_clazz, method, __FILE__, __LINE__, "msk");
     }
@@ -159,7 +159,7 @@ void permutation_group<N, T>::stabilize(
         const mask<N> &msk, permutation_group<N, T> &g2) {
 
     sequence<N, size_t> seq(0);
-    for (register size_t i = 0; i != N; i++) {
+    for (size_t i = 0; i != N; i++) {
         if (msk[i]) seq[i] = 1;
     }
     stabilize(seq, g2);
@@ -196,8 +196,8 @@ size_t permutation_group<N, T>::get_path(
     if(j <= i) return 0;
 
     size_t p[N];
-    register size_t k = j;
-    register size_t len = 0;
+    size_t k = j;
+    size_t len = 0;
     while(k != N && k != i) {
         p[len++] = k;
         k = br.m_edges[k];
@@ -395,7 +395,7 @@ template<size_t N, typename T>
 void permutation_group<N, T>::make_genset(
         const branching &br, perm_list_t &gs) const {
 
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(br.m_edges[i] != N && ! br.m_sigma[i].first.is_identity()) {
             gs.push_back(br.m_sigma[i]);
         }
@@ -459,8 +459,8 @@ template<size_t N, typename T>
 void permutation_group<N, T>::make_setstabilizer(const branching &br,
         const sequence<N, size_t> &msk, perm_list_t &gs) {
 
-    register size_t m = 0;
-    for(register size_t i = 0; i < N; i++) if(msk[i] != 0) m++;
+    size_t m = 0;
+    for(size_t i = 0; i < N; i++) if(msk[i] != 0) m++;
     // Handle two special cases first:
     // 1) mask is empty -> no stabilization
     if(m == 0) {

--- a/libtensor/symmetry/inst/se_label_impl.h
+++ b/libtensor/symmetry/inst/se_label_impl.h
@@ -92,7 +92,7 @@ bool se_label<N, T>::is_allowed(const index<N> &idx) const {
             const sequence<N, size_t> &seq = pr.get_sequence(ip);
 
             lg.clear();
-            register size_t i = 0;
+            size_t i = 0;
             for(; i < N; i++) {
                 if(seq[i] == 0) continue;
                 label_t l = m_blk_labels.get_label(m_blk_labels.get_dim_type(i),

--- a/libtensor/symmetry/inst/se_part_impl.h
+++ b/libtensor/symmetry/inst/se_part_impl.h
@@ -370,7 +370,7 @@ void se_part<N, T>::apply(index<N> &idx) const {
 
     //  Construct a mapped block index
     //
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         idx[i] -= (pidx1[i] - pidx2[i]) * m_bipdims[i];
     }
 }
@@ -392,7 +392,7 @@ void se_part<N, T>::apply(index<N> &idx, tensor_transf<N, T> &tr) const {
 
     //  Construct a mapped block index
     //
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         idx[i] -= (pidx1[i] - pidx2[i]) * m_bipdims[i];
     }
 
@@ -415,7 +415,7 @@ dimensions<N> se_part<N, T>::make_pdims(
 
     index<N> i1, i2;
     size_t m = 0;
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
         if(msk[i]) {
             i2[i] = npart - 1;
             m++;
@@ -451,7 +451,7 @@ dimensions<N> se_part<N, T>::make_bipdims(
         "const dimensions<N>&)";
 
     index<N> i1, i2;
-    for(register size_t i = 0; i < N; i++) {
+    for(size_t i = 0; i < N; i++) {
 #ifdef LIBTENSOR_DEBUG
         if(bidims[i] % pdims[i] != 0) {
             throw bad_symmetry(g_ns, k_clazz, method, __FILE__, __LINE__,
@@ -527,7 +527,7 @@ void se_part<N, T>::add_to_loop(size_t a, size_t b,
 template<size_t N, typename T>
 bool se_part<N, T>::is_valid_pidx(const index<N> &idx) {
 
-    for(register size_t i = 0; i < N; i++)
+    for(size_t i = 0; i < N; i++)
         if(idx[i] >= m_pdims[i]) return false;
     return true;
 }

--- a/libtensor/symmetry/inst/so_apply_se_perm_impl.h
+++ b/libtensor/symmetry/inst/so_apply_se_perm_impl.h
@@ -23,7 +23,7 @@ void symmetry_operation_impl< so_apply<N, T>, se_perm<N, T> >::do_perform(
     typedef std::list<transf_pair_t> transf_list_t;
 
     scalar_transf<T> tr(params.s2);
-    for (register size_t i = 1; i < N && ! tr.is_identity(); i++) {
+    for (size_t i = 1; i < N && ! tr.is_identity(); i++) {
         tr.transform(params.s2);
     }
     bool is_cyclic = tr.is_identity();

--- a/libtensor/symmetry/inst/so_dirprod_se_label_impl.h
+++ b/libtensor/symmetry/inst/so_dirprod_se_label_impl.h
@@ -90,7 +90,7 @@ symmetry_operation_impl< so_dirprod<N, M, T>, se_label<N + M, T> >::do_perform(
                         ip1 != pr1.end(); ip1++) {
 
                     const sequence<N, size_t> &seq1 = pr1.get_sequence(ip1);
-                    for (register size_t j = 0; j < N; j++)
+                    for (size_t j = 0; j < N; j++)
                         seq3[map1[j]] = seq1[j];
 
                     pr3.add(seq3, ip1->second);
@@ -139,7 +139,7 @@ symmetry_operation_impl< so_dirprod<N, M, T>, se_label<N + M, T> >::do_perform(
 
                         sequence<N + M, size_t> seq3(0);
                         const sequence<N, size_t> &seq1 = pr1.get_sequence(ip1);
-                        for (register size_t j = 0; j < N; j++)
+                        for (size_t j = 0; j < N; j++)
                             seq3[map1[j]] = seq1[j];
 
                         pr3.add(seq3, ip1->second);
@@ -151,7 +151,7 @@ symmetry_operation_impl< so_dirprod<N, M, T>, se_label<N + M, T> >::do_perform(
 
                         sequence<N + M, size_t> seq3(0);
                         const sequence<M, size_t> &seq2 = pr2.get_sequence(ip2);
-                        for (register size_t j = 0; j < M; j++)
+                        for (size_t j = 0; j < M; j++)
                             seq3[map2[j]] = seq2[j];
 
                         pr3.add(seq3, ip2->second);
@@ -209,7 +209,7 @@ symmetry_operation_impl< so_dirprod<N, M, T>, se_label<N + M, T> >::do_perform(
                     ip2 != pr2.end(); ip2++) {
 
                 const sequence<M, size_t> &seq2 = pr2.get_sequence(ip2);
-                for (register size_t j = 0; j < M; j++)
+                for (size_t j = 0; j < M; j++)
                     seq3[map2[j]] = seq2[j];
 
                 pr3.add(seq3, ip2->second);

--- a/libtensor/symmetry/inst/so_dirprod_se_perm_impl.h
+++ b/libtensor/symmetry/inst/so_dirprod_se_perm_impl.h
@@ -37,10 +37,10 @@ symmetry_operation_impl< so_dirprod<N, M, T>, se_perm<N + M, T> >::do_perform(
         //  space and form a symmetry element
         sequence<N + M, size_t> a2a(0), a2b(0);
 
-        for(register size_t k = 0; k < N; k++) {
+        for(size_t k = 0; k < N; k++) {
             a2a[map[k]] = k; a2b[map[k]] = e1.get_perm()[k];
         }
-        for(register size_t k = N; k < N + M; k++)
+        for(size_t k = N; k < N + M; k++)
             a2a[map[k]] = a2b[map[k]] = k;
 
         permutation_builder<N + M> pb(a2b, a2a);
@@ -58,9 +58,9 @@ symmetry_operation_impl< so_dirprod<N, M, T>, se_perm<N + M, T> >::do_perform(
         //  Project the permutation onto the larger
         //  space and form a symmetry element
         sequence<N + M, size_t> a2a(0), a2b(0);
-        for(register size_t k = 0; k < N; k++) a2a[map[k]] = a2b[map[k]] = k;
+        for(size_t k = 0; k < N; k++) a2a[map[k]] = a2b[map[k]] = k;
 
-        for(register size_t k = N, l = 0; k < N + M; k++, l++) {
+        for(size_t k = N, l = 0; k < N + M; k++, l++) {
             a2a[map[k]] = k; a2b[map[k]] = e2.get_perm()[l] + N;
         }
 

--- a/libtensor/symmetry/inst/so_dirsum_se_label_impl.h
+++ b/libtensor/symmetry/inst/so_dirsum_se_label_impl.h
@@ -80,7 +80,7 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_label<N + M, T> >::do_perform(
 
                 sequence<N + M, size_t> seq3(0);
                 const sequence<N, size_t> &seq1 = pr1.get_sequence(ip1);
-                for (register size_t j = 0; j < N; j++)
+                for (size_t j = 0; j < N; j++)
                     seq3[map1[j]] = seq1[j];
 
                 pr3.add(seq3, pr1.get_intrinsic(ip1));
@@ -98,7 +98,7 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_label<N + M, T> >::do_perform(
         if (it2 == g2.end()) {
             // Create a fake rule for non-existing e2 that allows all blocks
             sequence<N + M, size_t> seq3(0);
-            for (register size_t i = 0; i < M; i++) seq3[map2[i]] = 1;
+            for (size_t i = 0; i < M; i++) seq3[map2[i]] = 1;
 
             product_rule<N + M> &pr3 = r3.new_product();
             pr3.add(seq3, product_table_i::k_invalid);
@@ -136,7 +136,7 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_label<N + M, T> >::do_perform(
 
                     sequence<N + M, size_t> seq3(0);
                     const sequence<M, size_t> &seq2 = pr2.get_sequence(ip2);
-                    for (register size_t j = 0; j < M; j++)
+                    for (size_t j = 0; j < M; j++)
                         seq3[map2[j]] = seq2[j];
 
                     pr3.add(seq3, pr2.get_intrinsic(ip2));
@@ -176,7 +176,7 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_label<N + M, T> >::do_perform(
 
         // Create a fake rule for non-existing r1
         sequence<N + M, size_t> seq3(0);
-        for (register size_t i = 0; i < N; i++) seq3[map2[i]] = 1;
+        for (size_t i = 0; i < N; i++) seq3[map2[i]] = 1;
 
         product_rule<N + M> &pr3 = r3.new_product();
         pr3.add(seq3, product_table_i::k_invalid);
@@ -198,7 +198,7 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_label<N + M, T> >::do_perform(
 
                 sequence<N + M, size_t> seq3(0);
                 const sequence<M, size_t> &seq2 = pr2.get_sequence(ip2);
-                for (register size_t j = 0; j < M; j++)
+                for (size_t j = 0; j < M; j++)
                     seq3[map2[j]] = seq2[j];
 
                 pr3.add(seq3, pr2.get_intrinsic(ip2));

--- a/libtensor/symmetry/inst/so_dirsum_se_part_impl.h
+++ b/libtensor/symmetry/inst/so_dirsum_se_part_impl.h
@@ -29,8 +29,8 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
     permutation<N + M> pinv(params.perm, true);
     sequence<N, size_t> map1(0);
     sequence<M, size_t> map2(0);
-    for (register size_t i = 0; i < N; i++) map1[i] = pinv[i];
-    for (register size_t i = 0; i < M; i++) map2[i] = pinv[i + N];
+    for (size_t i = 0; i < N; i++) map1[i] = pinv[i];
+    for (size_t i = 0; i < M; i++) map2[i] = pinv[i + N];
 
     // First set is empty
     if (params.g1.is_empty()) {
@@ -67,7 +67,7 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
             while (i2a < i2b) {
                 scalar_transf<T> tr = se2.get_transf(i2a, i2b);
                 if (tr.is_identity()) {
-                    for (register size_t i = 0; i < M; i++) {
+                    for (size_t i = 0; i < M; i++) {
                         i3a[map2[i]] = i2a[i];
                         i3b[map2[i]] = i2b[i];
                     }
@@ -116,7 +116,7 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
             while (i1a < i1b) {
                 scalar_transf<T> tr = se1.get_transf(i1a, i1b);
                 if (tr.is_identity()) {
-                    for (register size_t i = 0; i < N; i++) {
+                    for (size_t i = 0; i < N; i++) {
                         i3a[map1[i]] = i1a[i];
                         i3b[map1[i]] = i1b[i];
                     }
@@ -157,9 +157,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
             const index<N + M> &i3 = ai3.get_index();
 
             index<N> i1a;
-            for (register size_t i = 0; i < N; i++) i1a[i] = i3[map1[i]];
+            for (size_t i = 0; i < N; i++) i1a[i] = i3[map1[i]];
             index<M> i2a;
-            for (register size_t i = 0; i < M; i++) i2a[i] = i3[map2[i]];
+            for (size_t i = 0; i < M; i++) i2a[i] = i3[map2[i]];
 
             bool fb1 = se1.is_forbidden(i1a);
             bool fb2 = se2.is_forbidden(i2a);
@@ -172,9 +172,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
                 // Try to create a map leaving se1 indexes fixed
                 index<M> i2b = se2.get_direct_map(i2a);
                 if (i2a < i2b) {
-                    for (register size_t i = 0; i < N; i++)
+                    for (size_t i = 0; i < N; i++)
                         i3b[map1[i]] = i1a[i];
-                    for (register size_t i = 0; i < M; i++)
+                    for (size_t i = 0; i < M; i++)
                         i3b[map2[i]] = i2b[i];
                     se3.add_map(i3, i3b, se2.get_transf(i2a, i2b));
                     continue;
@@ -189,9 +189,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
 
                     if (se1.is_forbidden(ai1b.get_index())) {
                         const index<N> &i1b = ai1b.get_index();
-                        for (register size_t i = 0; i < N; i++)
+                        for (size_t i = 0; i < N; i++)
                             i3b[map1[i]] = i1b[i];
-                        for (register size_t i = 0; i < M; i++)
+                        for (size_t i = 0; i < M; i++)
                             i3b[map2[i]] = i2a[i];
                         se3.add_map(i3, i3b, tr0);
                     }
@@ -207,9 +207,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
 
                     if (se2.is_forbidden(ai2b.get_index())) {
                         const index<M> &i2b = ai2b.get_index();
-                        for (register size_t i = 0; i < N; i++)
+                        for (size_t i = 0; i < N; i++)
                             i3b[map1[i]] = i1a[i];
-                        for (register size_t i = 0; i < M; i++)
+                        for (size_t i = 0; i < M; i++)
                             i3b[map2[i]] = i2b[i];
                         se3.add_map(i3, i3b, tr0);
                         continue;
@@ -218,9 +218,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
                 // Otherwise, try to create a map leaving se2 indexes fixed
                 index<N> i1b = se1.get_direct_map(i1a);
                 if (i1a < i1b) {
-                    for (register size_t i = 0; i < N; i++)
+                    for (size_t i = 0; i < N; i++)
                         i3b[map1[i]] = i1b[i];
-                    for (register size_t i = 0; i < M; i++)
+                    for (size_t i = 0; i < M; i++)
                         i3b[map2[i]] = i2a[i];
                     se3.add_map(i3, i3b, se1.get_transf(i1a, i1b));
                 }
@@ -234,9 +234,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
                     tr2 = se2.get_transf(i2a, i2b);
                 }
                 if (i2a < i2b) {
-                    for (register size_t i = 0; i < N; i++)
+                    for (size_t i = 0; i < N; i++)
                         i3b[map1[i]] = i1a[i];
-                    for (register size_t i = 0; i < M; i++)
+                    for (size_t i = 0; i < M; i++)
                         i3b[map2[i]] = i2b[i];
                     se3.add_map(i3, i3b, tr2);
                     continue;
@@ -249,9 +249,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
                     scalar_transf<T> tr1 = se1.get_transf(i1a, i1b);
                     // This can either be changing only indexes of 1
                     if (tr1.is_identity()) {
-                        for (register size_t i = 0; i < N; i++)
+                        for (size_t i = 0; i < N; i++)
                             i3b[map1[i]] = i1b[i];
-                        for (register size_t i = 0; i < M; i++)
+                        for (size_t i = 0; i < M; i++)
                             i3b[map2[i]] = i2a[i];
                         se3.add_map(i3, i3b, tr1);
                         break;
@@ -263,9 +263,9 @@ symmetry_operation_impl< so_dirsum<N, M, T>, se_part<N + M, T> >::do_perform(
                         i2b = se2.get_direct_map(i2b);
                     }
                     if (i2a != i2b) {
-                        for (register size_t i = 0; i < N; i++)
+                        for (size_t i = 0; i < N; i++)
                             i3b[map1[i]] = i1b[i];
-                        for (register size_t i = 0; i < M; i++)
+                        for (size_t i = 0; i < M; i++)
                             i3b[map2[i]] = i2b[i];
                         se3.add_map(i3, i3b, tr1);
                         break;

--- a/libtensor/symmetry/inst/so_dirsum_se_perm_impl.h
+++ b/libtensor/symmetry/inst/so_dirsum_se_perm_impl.h
@@ -20,8 +20,8 @@ do_perform(symmetry_operation_params_t &params) const {
     typedef symmetry_element_set_adapter< M, T, se_perm<M, T> > adapter2_t;
 
     mask<N + M> msk1, msk2;
-    for (register size_t k = 0; k < N; k++) msk1[k] = true;
-    for (register size_t k = N; k < N + M; k++) msk2[k] = true;
+    for (size_t k = 0; k < N; k++) msk1[k] = true;
+    for (size_t k = N; k < N + M; k++) msk2[k] = true;
 
     // Simplest case: both source groups are empty!
     if (params.g1.is_empty() && params.g2.is_empty()) {
@@ -147,8 +147,8 @@ combine(const permutation<N> &p1, const scalar_transf<T> &tr1,
     done.clear();
 
     sequence<N + M, size_t> seq2a, seq2b;
-    for (register size_t i = 0; i < N + M; i++) seq2a[i] = i;
-    for (register size_t i = 0; i < N; i++) seq2b[i] = p1[i];
+    for (size_t i = 0; i < N + M; i++) seq2a[i] = i;
+    for (size_t i = 0; i < N; i++) seq2b[i] = p1[i];
 
     // Combine all elements in p1 with all elements in p2
     if (! plst2.empty()) {
@@ -169,7 +169,7 @@ combine(const permutation<N> &p1, const scalar_transf<T> &tr1,
                         px.permute(it2->get_perm());
                         for (; k < i; k++) px.permute(it1->get_perm());
 
-                        for (register size_t i = 0, j = N; i < M; i++, j++)
+                        for (size_t i = 0, j = N; i < M; i++, j++)
                             seq2b[j] = px[i] + N;
 
                         permutation_builder<N + M> pb(seq2b, seq2a);
@@ -184,7 +184,7 @@ combine(const permutation<N> &p1, const scalar_transf<T> &tr1,
         for (typename perm_lst_t::iterator it = plst1.begin();
                 it != plst1.end(); it++) {
 
-            for (register size_t i = 0, j = N; i < M; i++, j++)
+            for (size_t i = 0, j = N; i < M; i++, j++)
                 seq2b[j] = it->get_perm()[i] + N;
             permutation_builder<N + M> pb(seq2b, seq2a);
             grp.add_orbit(tr1, pb.get_perm());
@@ -283,8 +283,8 @@ combine(const symmetry_element_set<N, T> &set1,
     done.clear();
 
     sequence<N + M, size_t> seq2a, seq2b;
-    for (register size_t i = 0; i < N + M; i++) seq2a[i] = i;
-    for (register size_t i = 0, j = N; i < M; i++, j++) seq2b[j] = p2[i] + N;
+    for (size_t i = 0; i < N + M; i++) seq2a[i] = i;
+    for (size_t i = 0, j = N; i < M; i++, j++) seq2b[j] = p2[i] + N;
 
     // Combine all elements in p1 with all elements in p2
     if (! plst2.empty()) {
@@ -305,7 +305,7 @@ combine(const symmetry_element_set<N, T> &set1,
                         px.permute(it2->get_perm());
                         for (; k < i; k++) px.permute(it1->get_perm());
 
-                        for (register size_t i = 0; i < N; i++)
+                        for (size_t i = 0; i < N; i++)
                             seq2b[i] = px[i];
 
                         permutation_builder<N + M> pb(seq2b, seq2a);
@@ -320,7 +320,7 @@ combine(const symmetry_element_set<N, T> &set1,
         for (typename perm_lst_t::iterator it = plst1.begin();
                 it != plst1.end(); it++) {
 
-            for (register size_t i = 0; i < N; i++)
+            for (size_t i = 0; i < N; i++)
                 seq2b[i] = it->get_perm()[i];
             permutation_builder<N + M> pb(seq2b, seq2a);
             grp.add_orbit(tr2, pb.get_perm());

--- a/libtensor/symmetry/inst/so_merge_impl.h
+++ b/libtensor/symmetry/inst/so_merge_impl.h
@@ -20,7 +20,7 @@ so_merge<N, M, T>::so_merge(const symmetry<N, T> &sym1,
     // Check the mask, and the sequence
     size_t m = 0;
     mask<M> msets;
-    register size_t i = 0;
+    size_t i = 0;
     for (; i < N; i++) {
         if (! msk[i]) continue;
         if (mseq[i] > M) break;

--- a/libtensor/symmetry/inst/so_merge_se_label_impl.h
+++ b/libtensor/symmetry/inst/so_merge_se_label_impl.h
@@ -31,7 +31,7 @@ symmetry_operation_impl< so_merge<N, M, T>, se_label<N - M, T> >::do_perform(
     sequence<N, size_t> mmap, lmap((size_t) -1);
     {
         sequence<M, size_t> msteps((size_t) -1);
-        for (register size_t i = 0, j = 0; i < N; i++) {
+        for (size_t i = 0, j = 0; i < N; i++) {
             if (params.msk[i]) {
                 if (msteps[params.mseq[i]] == (size_t) -1) {
                     lmap[i] = msteps[params.mseq[i]] = j++;

--- a/libtensor/symmetry/inst/so_merge_se_part_impl.h
+++ b/libtensor/symmetry/inst/so_merge_se_part_impl.h
@@ -26,7 +26,7 @@ symmetry_operation_impl< so_merge<N, M, T>, se_part<N - M, T> >::do_perform(
     // Determine index map N -> N - M
     mask<N> mm;
     sequence<N, size_t> map, mmap(N);
-    for (register size_t i = 0, j = 0; i < N; i++) {
+    for (size_t i = 0, j = 0; i < N; i++) {
         if (params.msk[i]) {
             if (mmap[params.mseq[i]] != N) {
                 map[i] = mmap[params.mseq[i]];
@@ -47,7 +47,7 @@ symmetry_operation_impl< so_merge<N, M, T>, se_part<N - M, T> >::do_perform(
 
     // Create result partition dimensions
     index<N - M> ia, ib;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (params.msk[i] && (! mm[i])) {
 
             size_t d1 = (ib[map[i]] + 1), d2 = pdims1[i];
@@ -63,7 +63,7 @@ symmetry_operation_impl< so_merge<N, M, T>, se_part<N - M, T> >::do_perform(
     if (pdims2.get_size() == 1) return;
 
     index<N> ja, jb1, jb2;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (pdims2[map[i]] == 0) {
             jb1[i] = pdims1[i];
         }
@@ -80,7 +80,7 @@ symmetry_operation_impl< so_merge<N, M, T>, se_part<N - M, T> >::do_perform(
     // Merge the partitions
     abs_index<N - M> ai(pdims2);
     do {
-        register size_t i;
+        size_t i;
 
         const index<N - M> &i2a = ai.get_index();
         // Create pre-merge index
@@ -143,7 +143,7 @@ is_forbidden(const el1_t &el, const index<N> &idx,
     while (aix.inc()) {
         const index<N> &ix = aix.get_index();
         index<N> ia;
-        for (register size_t i = 0; i < N; i++)
+        for (size_t i = 0; i < N; i++)
             ia[i] = idx[i] + ix[i];
 
         if (! el.is_forbidden(ia)) { forbidden = false; break; }
@@ -167,7 +167,7 @@ map_exists(const el1_t &el, const index<N> &ia,
     while (aix.inc() && exists) {
         const index<N> &ix = aix.get_index();
         index<N> i1a, i1b;
-        for (register size_t i = 0; i < N; i++) {
+        for (size_t i = 0; i < N; i++) {
             i1a[i] = ia[i] + ix[i];
             i1b[i] = ib[i] + ix[i];
         }

--- a/libtensor/symmetry/inst/so_merge_se_perm_impl.h
+++ b/libtensor/symmetry/inst/so_merge_se_perm_impl.h
@@ -43,7 +43,7 @@ symmetry_operation_impl< so_merge<N, M, T>, se_perm<N - M, T> >::do_perform(
     // Create the stabilizing sequence for permutation group
     mask<k_order1> msteps, mm;
     sequence<k_order1, size_t> sseq(0);
-    for (register size_t i = 0; i < k_order1; i++) {
+    for (size_t i = 0; i < k_order1; i++) {
         if (! params.msk[i]) continue;
 
         if (msteps[params.mseq[i]])
@@ -71,7 +71,7 @@ symmetry_operation_impl< so_merge<N, M, T>, se_perm<N - M, T> >::do_perform(
         sequence<k_order1, size_t> seq1a(0), seq2a(0);
         sequence<k_order2, size_t> seq1b(0), seq2b(0);
 
-        for (register size_t i = 0; i < k_order1; i++)
+        for (size_t i = 0; i < k_order1; i++)
             seq1a[i] = seq2a[i] = i;
         e2.get_perm().apply(seq2a);
 

--- a/libtensor/symmetry/inst/so_reduce_impl.h
+++ b/libtensor/symmetry/inst/so_reduce_impl.h
@@ -22,7 +22,7 @@ so_reduce<N, M, T>::so_reduce(const symmetry<N, T> &sym1,
     size_t m = 0;
     mask<M> rsets;
     index<M> rbia, rbib, ria, rib;
-    register size_t i = 0;
+    size_t i = 0;
     for (; i < N; i++) {
         if (! msk[i]) continue;
         if (rseq[i] > M) break;
@@ -44,7 +44,7 @@ so_reduce<N, M, T>::so_reduce(const symmetry<N, T> &sym1,
     }
 
     for (i = 0; i < M && rsets[i]; i++) {
-        register size_t j = 0;
+        size_t j = 0;
         for (; j < N; j++) {
             if (! msk[j] || rseq[j] != i) continue;
             if (rblrange.get_begin()[j] != rbia[i] ||

--- a/libtensor/symmetry/inst/so_reduce_se_label_impl.h
+++ b/libtensor/symmetry/inst/so_reduce_se_label_impl.h
@@ -37,7 +37,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_label<N - M, T> >::do_perform(
     // Create a map of remaining indexes
     sequence<k_order1, size_t> map(0), rmap(0);
     size_t nrsteps = 0;
-    for (register size_t i = 0, j = 0; i < k_order1; i++) {
+    for (size_t i = 0, j = 0; i < k_order1; i++) {
         if (params.msk[i]) {
             map[i] = size_t(-1);
             rmap[i] = params.rseq[i] + k_order2;

--- a/libtensor/symmetry/inst/so_reduce_se_part_impl.h
+++ b/libtensor/symmetry/inst/so_reduce_se_part_impl.h
@@ -24,7 +24,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::do_perform(
 
     // Create the inverse of the mask
     mask<NA> invmsk;
-    for (register size_t i = 0; i < NA; i++)
+    for (size_t i = 0; i < NA; i++)
         invmsk[i] = !params.msk[i];
 
     params.g2.clear();
@@ -33,7 +33,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::do_perform(
     // Create a map of indexes and a mask of reduction steps
     sequence<NA, size_t> map(0);
     mask<NR> rsteps;
-    for (register size_t i = 0, j = 0; i < NA; i++) {
+    for (size_t i = 0, j = 0; i < NA; i++) {
         if (params.msk[i]) {
             rsteps[params.rseq[i]] = true;
             map[i] = NB + params.rseq[i];
@@ -54,9 +54,9 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::do_perform(
     // - partition size (rpsz == nix)
     // - partitions in reduction range (irpa == ixa, irpb, ixb)
     index<NR> rpsz, i1rp, i2rp;
-    for (register size_t i = 0; i < NR && rsteps[i]; i++) {
+    for (size_t i = 0; i < NR && rsteps[i]; i++) {
 
-        register size_t j = 0;
+        size_t j = 0;
         for (; j < NA; j++) {
             if (params.msk[j] && params.rseq[j] == i) break;
         }
@@ -83,7 +83,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::do_perform(
     // Determine the sizes of the remaining dimensions
     index<NB> i1, i2;
     index<NA> j1, j2;
-    for (register size_t i = 0; i < NA; i++) {
+    for (size_t i = 0; i < NA; i++) {
         if (params.msk[i]) {
             j2[i] = pdimsa[i] / rpsz[params.rseq[i]] - 1;
         }
@@ -117,7 +117,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::do_perform(
             const index<NR> &idx = ai1.get_index();
 
             index<NA> ia;
-            for (register size_t i = 0, j = 0; i < NA; i++) {
+            for (size_t i = 0, j = 0; i < NA; i++) {
                 if (params.msk[i]) {
                     size_t ir = params.rseq[i];
                     ia[i] = (i1rp[ir] + idx[ir]) * pdimsr[i];
@@ -180,7 +180,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::do_perform(
                 const index<NR> &idx = ai2.get_index();
 
                 index<NA> ia;
-                for (register size_t i = 0, j = 0; i < NA; i++) {
+                for (size_t i = 0, j = 0; i < NA; i++) {
                     if (params.msk[i]) {
                         size_t ir = params.rseq[i];
                         ia[i] = (i1rp[ir] + idx[ir]) * pdimsr[i];
@@ -273,7 +273,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::is_forbidden(
     while (ai.inc()) {
         const index<NA> &ix = ai.get_index();
         index<NA> ia;
-        for (register size_t i = 0; i < NA; i++) ia[i] = idx[i] + ix[i];
+        for (size_t i = 0; i < NA; i++) ia[i] = idx[i] + ix[i];
 
         if (! el.is_forbidden(ia)) { forbidden = false; break; }
     }
@@ -296,7 +296,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_part<N - M, T> >::map_exists(
     while (ai.inc() && exists) {
         const index<NA> &ix = ai.get_index();
         index<NA> ia1, ia2;
-        for (register size_t i = 0; i < NA; i++) {
+        for (size_t i = 0; i < NA; i++) {
             ia1[i] = i1[i] + ix[i];
             ia2[i] = i2[i] + ix[i];
         }

--- a/libtensor/symmetry/inst/so_reduce_se_perm_impl.h
+++ b/libtensor/symmetry/inst/so_reduce_se_perm_impl.h
@@ -29,7 +29,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_perm<N - M, T> >::do_perform(
     permutation_group<k_order1, T> group2;
 
     sequence<k_order1, size_t> seq(0);
-    for (register size_t i = 0; i < k_order1; i++) {
+    for (size_t i = 0; i < k_order1; i++) {
         if (params.msk[i]) seq[i] = params.rseq[i] + 1;
     }
     group1.stabilize(seq, group2);
@@ -57,7 +57,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_perm<N - M, T> >::do_perform(
         ia2.permute(e2.get_perm());
         ib2.permute(e2.get_perm());
 
-        register size_t j = 0;
+        size_t j = 0;
         for (; j < k_order1; j++) {
             if (! params.msk[j]) continue;
             if (bia2[j] != bia[j] || bib2[j] != bib[j] ||
@@ -70,7 +70,7 @@ symmetry_operation_impl< so_reduce<N, M, T>, se_perm<N - M, T> >::do_perform(
         for (j = 0; j < k_order1; j++) seq1a[j] = seq2a[j] = j;
         e2.get_perm().apply(seq2a);
 
-        for (register size_t j = 0, k = 0; j < k_order1; j++) {
+        for (size_t j = 0, k = 0; j < k_order1; j++) {
             if (params.msk[j]) continue;
 
             seq1b[k] = seq1a[j];

--- a/libtensor/symmetry/inst/so_symmetrize_impl.h
+++ b/libtensor/symmetry/inst/so_symmetrize_impl.h
@@ -21,7 +21,7 @@ so_symmetrize<N, T>::so_symmetrize(const symmetry<N, T> &sym1,
 
     size_t ngrp = 0, nidx = 0;
     sequence<N, size_t> nidxs(0), ngrps(0);
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (m_idxgrp[i] == 0 || m_symidx[i] == 0) {
             if (m_idxgrp[i] != m_symidx[i]) {
                 throw bad_symmetry(g_ns, k_clazz, method,
@@ -46,7 +46,7 @@ so_symmetrize<N, T>::so_symmetrize(const symmetry<N, T> &sym1,
         ngrps[m_symidx[i] - 1]++;
     }
 
-    register size_t j = 0;
+    size_t j = 0;
     for (; j < N && (ngrps[j] != 0); j++) {
         if (ngrps[j] != ngrp) {
             throw bad_parameter(g_ns, k_clazz, method,
@@ -88,7 +88,7 @@ template<size_t N, typename T>
 void so_symmetrize<N, T>::perform(symmetry<N, T> &sym2) {
 
     size_t ngrp = 0;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (m_idxgrp[i] == 0) continue;
         ngrp = std::max(ngrp, m_idxgrp[i]);
     }

--- a/libtensor/symmetry/inst/so_symmetrize_se_label_impl.h
+++ b/libtensor/symmetry/inst/so_symmetrize_se_label_impl.h
@@ -28,7 +28,7 @@ symmetry_operation_impl< so_symmetrize<N, T>, se_label<N, T> >::do_perform(
     params.g2.clear();
 
     size_t ngrp = 0, nidx = 0;
-     for (register size_t i = 0; i < N; i++) {
+     for (size_t i = 0; i < N; i++) {
          ngrp = std::max(ngrp, params.idxgrp[i]);
          nidx = std::max(nidx, params.symidx[i]);
      }
@@ -36,11 +36,11 @@ symmetry_operation_impl< so_symmetrize<N, T>, se_label<N, T> >::do_perform(
 
      // Mask for permutation generator: permuted are only index groups
      mask<N> msk;
-     for (register size_t i = ngrp; i < N; i++) msk[i] = true;
+     for (size_t i = ngrp; i < N; i++) msk[i] = true;
 
      // Maps for symmetrization and transfer of block labels.
      sequence<N, size_t> map, idmap;
-     for (register size_t i = 0; i < N; i++) {
+     for (size_t i = 0; i < N; i++) {
          idmap[i] = i;
          if (params.idxgrp[i] == 0) continue;
          map[(params.idxgrp[i] - 1) * nidx + params.symidx[i] - 1] = i;
@@ -52,11 +52,11 @@ symmetry_operation_impl< so_symmetrize<N, T>, se_label<N, T> >::do_perform(
          const block_labeling<N> &bl1 = e1.get_labeling();
          const evaluation_rule<N> &r1 = e1.get_rule();
 
-         for (register size_t i = 0; i < nidx; i++) {
+         for (size_t i = 0; i < nidx; i++) {
 
              size_t typei = bl1.get_dim_type(map[i]);
              size_t k = i + nidx;
-             for (register size_t j = 1; j < ngrp; j++) {
+             for (size_t j = 1; j < ngrp; j++) {
                  if (bl1.get_dim_type(map[k]) != typei)
                      throw bad_symmetry(g_ns, k_clazz, method,
                              __FILE__, __LINE__, "Incompatible dimensions.");
@@ -79,10 +79,10 @@ symmetry_operation_impl< so_symmetrize<N, T>, se_label<N, T> >::do_perform(
              do {
                  const permutation<N> &p = pg.get_perm();
                  sequence<N, size_t> seq1(0), seq2(0);
-                 for (register size_t i = 0; i < N; i++) seq1[i] = seq2[i] = i;
+                 for (size_t i = 0; i < N; i++) seq1[i] = seq2[i] = i;
 
-                 for (register size_t i = 0, k = 0; i < ngrp; i++) {
-                     for (register size_t j = 0, kk = p[i] * nidx;
+                 for (size_t i = 0, k = 0; i < ngrp; i++) {
+                     for (size_t j = 0, kk = p[i] * nidx;
                              j < nidx; j++, k++, kk++) {
                          seq2[map[kk]] = seq1[map[k]];
                      }

--- a/libtensor/symmetry/inst/so_symmetrize_se_part_impl.h
+++ b/libtensor/symmetry/inst/so_symmetrize_se_part_impl.h
@@ -25,7 +25,7 @@ void symmetry_operation_impl< so_symmetrize<N, T>, se_part<N, T> >::do_perform(
     const dimensions<N> &pdims = cp.get_pdims();
 
     size_t ngrp = 0, nidx = 0;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (params.idxgrp[i] == 0) continue;
 
         ngrp = std::max(ngrp, params.idxgrp[i]);
@@ -33,20 +33,20 @@ void symmetry_operation_impl< so_symmetrize<N, T>, se_part<N, T> >::do_perform(
     }
 
     sequence<N, size_t> map(N);
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (params.idxgrp[i] == 0) continue;
         map[(params.symidx[i] - 1) * ngrp + params.idxgrp[i] - 1] = i;
     }
 
     mask<N> msk;
-    for (register size_t i = ngrp; i < N; i++) msk[i] = true;
+    for (size_t i = ngrp; i < N; i++) msk[i] = true;
 
     //  If the elements are partitioned differently,
     //  the result is no symmetry 
     bool no_symmetry = false;
-    for(register size_t i = 1; i < ngrp; i++) {
+    for(size_t i = 1; i < ngrp; i++) {
         size_t in = i * nidx;
-        for(register size_t j = 0; j < nidx; j++) {
+        for(size_t j = 0; j < nidx; j++) {
             if(pdims[map[in + j]] != pdims[map[j]]) no_symmetry = true;
         }
     }
@@ -92,11 +92,11 @@ symmetry_operation_impl< so_symmetrize<N, T>, se_part<N, T> >::is_forbidden(
     permutation_generator<N> pg(msk);
     do {
         const permutation<N> &pn = pg.get_perm();
-        register size_t i = 0;
+        size_t i = 0;
         for (; i < N && ! msk[i]; i++) ix[map[i]] = i1[map[pn[i]]];
         size_t ngrp = i, ns = ngrp;
         while (i < N && map[i] < N) {
-            for (register size_t j = 0; j < ngrp; j++, i++) {
+            for (size_t j = 0; j < ngrp; j++, i++) {
                 ix[map[i]] = i1[map[pn[j] + ns]];
             }
             ns += ngrp;
@@ -117,11 +117,11 @@ symmetry_operation_impl< so_symmetrize<N, T>, se_part<N, T> >::mark_forbidden(
     permutation_generator<N> pg(msk);
     do {
         const permutation<N> &pn = pg.get_perm();
-        register size_t i = 0;
+        size_t i = 0;
         for (; i < N && ! msk[i]; i++) ix[map[i]] = i1[map[pn[i]]];
         size_t ngrp = i, ns = ngrp;
         while (i < N && map[i] < N) {
-            for (register size_t j = 0; j < ngrp; j++, i++) {
+            for (size_t j = 0; j < ngrp; j++, i++) {
                 ix[map[i]] = i1[map[pn[j] + ns]];
             }
             ns += ngrp;
@@ -140,14 +140,14 @@ bool symmetry_operation_impl< so_symmetrize<N, T>, se_part<N, T> >::map_exists(
     scalar_transf<T> tr;
     do {
         const permutation<N> &pn = pg.get_perm();
-        register size_t i = 0;
+        size_t i = 0;
         for (; i < N && ! msk[i]; i++) {
             j1[map[i]] = i1[map[pn[i]]];
             j2[map[i]] = i2[map[pn[i]]];
         }
         size_t ngrp = i, ns = ngrp;
         while (i < N && map[i] < N) {
-            for (register size_t j = 0; j < ngrp; j++, i++) {
+            for (size_t j = 0; j < ngrp; j++, i++) {
                 j1[map[i]] = i1[map[pn[j] + ns]];
                 j2[map[i]] = i2[map[pn[j] + ns]];
             }
@@ -165,14 +165,14 @@ bool symmetry_operation_impl< so_symmetrize<N, T>, se_part<N, T> >::map_exists(
 
     while (pg.next()) {
         const permutation<N> &pn = pg.get_perm();
-        register size_t i = 0;
+        size_t i = 0;
         for (; i < N && ! msk[i]; i++) {
             j1[map[i]] = i1[map[pn[i]]];
             j2[map[i]] = i2[map[pn[i]]];
         }
         size_t ngrp = i, ns = ngrp;
         while (i < N && map[i] < N) {
-            for (register size_t j = 0; j < ngrp; j++, i++) {
+            for (size_t j = 0; j < ngrp; j++, i++) {
                 j1[map[i]] = i1[map[pn[j] + ns]];
                 j2[map[i]] = i2[map[pn[j] + ns]];
             }
@@ -200,14 +200,14 @@ void symmetry_operation_impl< so_symmetrize<N, T>, se_part<N, T> >::add_map(
     permutation_generator<N> pg(msk);
     do {
         const permutation<N> &pn = pg.get_perm();
-        register size_t i = 0;
+        size_t i = 0;
         for (; i < N && ! msk[i]; i++) {
             j1[map[i]] = i1[map[pn[i]]];
             j2[map[i]] = i2[map[pn[i]]];
         }
         size_t ngrp = i, ns = ngrp;
         while (i < N && map[i] < N) {
-            for (register size_t j = 0; j < ngrp; j++, i++) {
+            for (size_t j = 0; j < ngrp; j++, i++) {
                 j1[map[i]] = i1[map[pn[j] + ns]];
                 j2[map[i]] = i2[map[pn[j] + ns]];
             }

--- a/libtensor/symmetry/inst/so_symmetrize_se_perm_impl.h
+++ b/libtensor/symmetry/inst/so_symmetrize_se_perm_impl.h
@@ -24,7 +24,7 @@ void symmetry_operation_impl< so_symmetrize<N, T>, se_perm<N, T> >::do_perform(
 
     // Number of groups and number of indexes per group
     size_t ngrp = 0, nidx = 0;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (params.idxgrp[i] == 0) continue;
         ngrp = std::max(ngrp, params.idxgrp[i]);
         nidx = std::max(nidx, params.symidx[i]);
@@ -33,7 +33,7 @@ void symmetry_operation_impl< so_symmetrize<N, T>, se_perm<N, T> >::do_perform(
     // Create map and msk
     sequence<N, size_t> map(0);
     mask<N> msk;
-    for (register size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         if (params.idxgrp[i] == 0) { msk[i] = true; continue; }
         map[(params.idxgrp[i] - 1) * nidx + params.symidx[i] - 1] = i;
         msk[i] = (params.symidx[i] != 1);
@@ -43,7 +43,7 @@ void symmetry_operation_impl< so_symmetrize<N, T>, se_perm<N, T> >::do_perform(
     permutation<N> pp, cp;
     for (size_t k = 1; k < ngrp; k++) {
         for (size_t i = 1 ; i <= nidx; i++) {
-            register size_t j = 0;
+            size_t j = 0;
             for (; j < N; j++) {
                 if ((params.idxgrp[j] == k) &&
                         (params.symidx[j] == i)) break;
@@ -174,9 +174,9 @@ size_t symmetry_operation_impl< so_symmetrize<N, T>, se_perm<N, T> >::encode(
 
     permutation<N> pinv(p, true);
     size_t idx = 0;
-    for (register size_t i = 0, j = N; i != N - 1; i++, j--) {
+    for (size_t i = 0, j = N; i != N - 1; i++, j--) {
         size_t ii = 0;
-        for (register size_t k = 0; k < pinv[i]; k++) {
+        for (size_t k = 0; k < pinv[i]; k++) {
             if (p[k] > i) ii++;
         }
         idx = idx * j + ii;

--- a/libtensor/symmetry/permutation_group.h
+++ b/libtensor/symmetry/permutation_group.h
@@ -44,10 +44,10 @@ private:
         gen_perm_t m_tau[N]; //!< Vertex labels (permutation + n)
         size_t m_edges[N]; //!< Edge sources
         branching() {
-            for(register size_t i = 0; i < N; i++) m_edges[i] = N;
+            for(size_t i = 0; i < N; i++) m_edges[i] = N;
         }
         void reset() {
-            for(register size_t i = 0; i < N; i++) {
+            for(size_t i = 0; i < N; i++) {
                 m_edges[i] = N;
                 m_sigma[i].first.reset();
                 m_tau[i].first.reset();

--- a/libtensor/symmetry/point_group_table.C
+++ b/libtensor/symmetry/point_group_table.C
@@ -82,11 +82,11 @@ void point_group_table::product(const label_group_t &lg,
     if (lg.empty()) return;
 
     label_group_t::const_iterator it = lg.begin();
-    register size_t pr1 = (1 << *it);
+    size_t pr1 = (1 << *it);
     it++;
     for (; it != lg.end(); it++) {
-        register size_t pr2 = 0;
-        for (register label_t i = 0, bit = 1;
+        size_t pr2 = 0;
+        for (label_t i = 0, bit = 1;
                 i < m_irreps.size(); i++, bit <<= 1) {
             if ((pr1 & bit) == bit)
                 pr2 |= m_table[*it > i ?
@@ -95,7 +95,7 @@ void point_group_table::product(const label_group_t &lg,
         pr1 = pr2;
     }
 
-    for (register label_t i = 0, bit = 1; i < m_irreps.size(); i++, bit <<= 1) {
+    for (label_t i = 0, bit = 1; i < m_irreps.size(); i++, bit <<= 1) {
         if ((pr1 & bit) == bit) prod.insert(i);
     }
 }
@@ -115,11 +115,11 @@ bool point_group_table::is_in_product(
     if (lg.empty()) return false;
 
     label_group_t::const_iterator it = lg.begin();
-    register size_t pr1 = (1 << *it);
+    size_t pr1 = (1 << *it);
     it++;
     for (; it != lg.end(); it++) {
-        register size_t pr2 = 0;
-        for (register size_t i = 0, bit = 1;
+        size_t pr2 = 0;
+        for (size_t i = 0, bit = 1;
                 i < m_irreps.size(); i++, bit <<= 1) {
             if ((pr1 & bit) == bit)
                 pr2 |= m_table[*it > i ?
@@ -128,7 +128,7 @@ bool point_group_table::is_in_product(
         pr1 = pr2;
     }
 
-    register size_t rbit = (1 << l);
+    size_t rbit = (1 << l);
     return (pr1 & rbit) == rbit;
 }
 

--- a/libtensor/symmetry/point_group_table.C
+++ b/libtensor/symmetry/point_group_table.C
@@ -45,7 +45,7 @@ point_group_table::get_label(const std::string &irrep) const {
 }
 
 void point_group_table::add_product(label_t l1, label_t l2,
-        label_t lr) throw(bad_parameter) {
+        label_t lr) {
 
     const char *method = "add_product(label_t, label_t, label_t)";
 

--- a/libtensor/symmetry/point_group_table.h
+++ b/libtensor/symmetry/point_group_table.h
@@ -126,7 +126,7 @@ public:
         \param lr Result label
         \throw out_of_bounds If l1, l2 or lr are not valid.
      **/
-    void add_product(label_t l1, label_t l2, label_t lr) throw(bad_parameter);
+    void add_product(label_t l1, label_t l2, label_t lr);
 
     /** \brief Reset the product table
      **/

--- a/libtensor/symmetry/print_symmetry.h
+++ b/libtensor/symmetry/print_symmetry.h
@@ -176,7 +176,7 @@ std::ostream &operator<<(std::ostream &os, const product_rule<N> &pr) {
             it != pr.end(); it++) {
         os << "([";
         const sequence<N, size_t> &seq = pr.get_sequence(it);
-        for (register size_t j = 0; j < N; j++) os << seq[j];
+        for (size_t j = 0; j < N; j++) os << seq[j];
         os << "], ";
         product_table_i::label_t l = pr.get_intrinsic(it);
         if (l == product_table_i::k_invalid) os << "*";

--- a/libtensor/symmetry/product_table_container.C
+++ b/libtensor/symmetry/product_table_container.C
@@ -15,7 +15,7 @@ product_table_container::~product_table_container() {
 }
 
 void product_table_container::add(
-        const product_table_i &pt) throw(bad_parameter) {
+        const product_table_i &pt) {
 
     static const char *method = "add(product_table_i &)";
 
@@ -39,7 +39,7 @@ void product_table_container::add(
 }
 
 void product_table_container::erase(
-        const std::string &id) throw(bad_parameter, generic_exception) {
+        const std::string &id) {
 
     const char *method = "erase(const id_t &)";
 
@@ -58,7 +58,7 @@ void product_table_container::erase(
 }
 
 product_table_i &product_table_container::req_table(
-        const std::string &id) throw(bad_parameter, exception) {
+        const std::string &id) {
 
     const char *method = "req_table(const id_t&)";
 
@@ -77,7 +77,7 @@ product_table_i &product_table_container::req_table(
 }
 
 const product_table_i &product_table_container::req_const_table(
-        const std::string &id) throw(bad_parameter, exception) {
+        const std::string &id) {
 
     const char *method = "req_table(const id_t&)";
 
@@ -96,7 +96,7 @@ const product_table_i &product_table_container::req_const_table(
 }
 
 void product_table_container::ret_table(
-        const std::string &id) throw(bad_parameter) {
+        const std::string &id) {
 
     const char *method = "ret_table(const id_t&)";
 

--- a/libtensor/symmetry/product_table_container.h
+++ b/libtensor/symmetry/product_table_container.h
@@ -51,7 +51,7 @@ public:
         \param pt Product table to add
         \throw bad_parameter If table with id already exists
      **/
-    void add(const product_table_i &pt) throw(bad_parameter);
+    void add(const product_table_i &pt);
 
     /** \brief Remove product table (if it exists)
 
@@ -59,7 +59,7 @@ public:
         \throw bad_parameter If table does not exists.
         \throw exception If table has been checked out for reading or writing.
      **/
-    void erase(const std::string &id) throw(bad_parameter, generic_exception);
+    void erase(const std::string &id);
 
     /** \brief Request product table for writing
 
@@ -69,7 +69,7 @@ public:
         \throw exception If table has been checked out for reading or writing.
      **/
     product_table_i &req_table(
-            const std::string &id) throw(bad_parameter, exception);
+            const std::string &id);
 
     //@}
 
@@ -82,18 +82,18 @@ public:
         \throw exception If table has been checked out for writing.
      **/
     const product_table_i &req_const_table(
-            const std::string &id) throw (bad_parameter, exception);
+            const std::string &id);
 
 
     template<typename PTT>
-    const PTT &req_const_table(const std::string &id) throw (generic_exception);
+    const PTT &req_const_table(const std::string &id);
 
     /** \brief Return checked out product table
 
         \param id Table id.
         \throw bad_parameter If table does not exists.
      **/
-    void ret_table(const std::string &id) throw(bad_parameter);
+    void ret_table(const std::string &id);
 
     bool table_exists(const std::string &id);
 
@@ -108,7 +108,7 @@ private:
 
 template<typename PTT>
 const PTT &product_table_container::req_const_table(
-        const std::string &id) throw (generic_exception) {
+        const std::string &id) {
 
        const product_table_i &pt = req_const_table(id);
        try {

--- a/libtensor/symmetry/product_table_i.C
+++ b/libtensor/symmetry/product_table_i.C
@@ -14,7 +14,7 @@ const product_table_i::label_t product_table_i::k_invalid =
 const product_table_i::label_t product_table_i::k_identity = 0;
 
 
-void product_table_i::check() const throw(bad_symmetry) {
+void product_table_i::check() const {
 
 #ifdef LIBTENSOR_DEBUG
     static const char *method = "check() const";

--- a/libtensor/symmetry/product_table_i.h
+++ b/libtensor/symmetry/product_table_i.h
@@ -88,7 +88,7 @@ public:
         Checks that the product of any label with the identity label yields the
         respective label and that all products yield a non-empty set.
      **/
-    void check() const throw(bad_symmetry);
+    void check();
 
 protected:
     /** \brief Perform additional consistency check

--- a/libtensor/symmetry/product_table_i.h
+++ b/libtensor/symmetry/product_table_i.h
@@ -88,7 +88,7 @@ public:
         Checks that the product of any label with the identity label yields the
         respective label and that all products yield a non-empty set.
      **/
-    void check();
+    void check() const;
 
 protected:
     /** \brief Perform additional consistency check

--- a/libtensor/symmetry/symmetry_element_target.h
+++ b/libtensor/symmetry/symmetry_element_target.h
@@ -14,8 +14,7 @@ public:
     //!    \name Implementation of
     //!        libtensor::symmetry_element_target_i<N, T>
     //@{
-    virtual void accept_default(const symmetry_element_i<N, T> &elem)
-    throw(exception) { };
+    virtual void accept_default(const symmetry_element_i<N, T> &elem) { };
     //@}
 
 };
@@ -26,7 +25,7 @@ class symmetry_element_target :
     virtual public symmetry_element_target_base<N, T> {
 
     public:
-        virtual void accept(const ElemT &elem) throw(exception) { };
+        virtual void accept(const ElemT &elem) { };
     };
 
 
@@ -35,8 +34,7 @@ class symmetry_element_target :
     virtual public symmetry_element_target_base<N, T> {
 
     public:
-        virtual void accept(const symmetry_element_i<N, T> &elem)
-        throw(exception) {
+        virtual void accept(const symmetry_element_i<N, T> &elem) {
 
             accept_default(elem);
         };

--- a/libutil/exceptions/exception.C
+++ b/libutil/exceptions/exception.C
@@ -7,7 +7,7 @@ namespace libutil {
 
 void exception::init(const char *ns, const char *clazz, const char *method,
     const char *file, unsigned int line, const char *type,
-    const char *message) throw() {
+    const char *message) noexcept {
 
     if(ns == NULL) m_ns[0] = '\0';
     else { strncpy(m_ns, ns, 128); m_ns[127] = '\0'; }
@@ -102,7 +102,7 @@ void exception::init(const char *ns, const char *clazz, const char *method,
 }
 
 
-const char *exception::what() const throw() {
+const char *exception::what() const noexcept {
 
     return m_what;
 }

--- a/libutil/exceptions/exception.C
+++ b/libutil/exceptions/exception.C
@@ -7,7 +7,7 @@ namespace libutil {
 
 void exception::init(const char *ns, const char *clazz, const char *method,
     const char *file, unsigned int line, const char *type,
-    const char *message) throw() {
+    const char *message) {
 
     if(ns == NULL) m_ns[0] = '\0';
     else { strncpy(m_ns, ns, 128); m_ns[127] = '\0'; }
@@ -102,8 +102,7 @@ void exception::init(const char *ns, const char *clazz, const char *method,
 }
 
 
-const char *exception::what() const throw() {
-
+const char *exception::what() const noexcept {
     return m_what;
 }
 

--- a/libutil/exceptions/exception.h
+++ b/libutil/exceptions/exception.h
@@ -38,7 +38,7 @@ public:
      **/
     exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *type,
-        const char *message) throw() {
+        const char *message) noexcept {
 
         init(ns, clazz, method, file, line, type, message);
     }
@@ -53,7 +53,7 @@ public:
 
     /**	\brief Virtual destructor
 	 **/
-	virtual ~exception() throw() { };
+	virtual ~exception() noexcept { };
 
 	//@}
 
@@ -63,14 +63,14 @@ public:
 
 	/**	\brief Returns the cause of the exception (message)
 	 **/
-	virtual const char *what() const throw();
+	virtual const char *what() const noexcept;
 
 	//@}
 
 private:
 	void init(const char *ns, const char *clazz, const char *method,
 	        const char *file, unsigned int line, const char *type,
-	        const char *message) throw();
+	        const char *message) noexcept;
 };
 
 

--- a/libutil/exceptions/exception.h
+++ b/libutil/exceptions/exception.h
@@ -38,7 +38,7 @@ public:
      **/
     exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *type,
-        const char *message) throw() {
+        const char *message) {
 
         init(ns, clazz, method, file, line, type, message);
     }
@@ -53,7 +53,7 @@ public:
 
     /**	\brief Virtual destructor
 	 **/
-	virtual ~exception() throw() { };
+	virtual ~exception() { };
 
 	//@}
 
@@ -63,14 +63,14 @@ public:
 
 	/**	\brief Returns the cause of the exception (message)
 	 **/
-	virtual const char *what() const throw();
+	virtual const char *what() const noexcept;
 
 	//@}
 
 private:
 	void init(const char *ns, const char *clazz, const char *method,
 	        const char *file, unsigned int line, const char *type,
-	        const char *message) throw();
+	        const char *message);
 };
 
 

--- a/libutil/exceptions/exception_base.h
+++ b/libutil/exceptions/exception_base.h
@@ -29,25 +29,25 @@ public:
 	 **/
 	exception_base(const char *ns, const char *clazz, const char *method,
 		const char *file, unsigned int line, const char *type,
-		const char *message) throw() :
+		const char *message) noexcept :
 		exception(ns, clazz, method, file, line, type, message) {
 	}
 
 	/**	\brief Copy constructor
 	 **/
-	exception_base(const exception_base<Exc> &e) throw() :
+	exception_base(const exception_base<Exc> &e) noexcept :
 	    exception(e) {
 	}
 
 	/**	\brief Virtual destructor
 	 **/
-	virtual ~exception_base() throw() { };
+	virtual ~exception_base() noexcept { };
 
 	//@}
 
 	/**	\brief Clones the object
 	 **/
-	virtual rethrowable_i *clone() const throw() {
+	virtual rethrowable_i *clone() const noexcept {
 		try {
 			const Exc &e = dynamic_cast<const Exc&>(*this);
 			return new Exc(e);

--- a/libutil/exceptions/exception_base.h
+++ b/libutil/exceptions/exception_base.h
@@ -29,7 +29,7 @@ public:
 	 **/
 	exception_base(const char *ns, const char *clazz, const char *method,
 		const char *file, unsigned int line, const char *type,
-		const char *message) throw() :
+		const char *message) :
 		exception(ns, clazz, method, file, line, type, message) {
 	}
 

--- a/libutil/exceptions/rethrowable_i.C
+++ b/libutil/exceptions/rethrowable_i.C
@@ -3,7 +3,7 @@
 namespace libutil {
 
 
-rethrowable_i::~rethrowable_i() throw() {
+rethrowable_i::~rethrowable_i() noexcept {
 
 }
 

--- a/libutil/exceptions/rethrowable_i.C
+++ b/libutil/exceptions/rethrowable_i.C
@@ -3,7 +3,7 @@
 namespace libutil {
 
 
-rethrowable_i::~rethrowable_i() throw() {
+rethrowable_i::~rethrowable_i() {
 
 }
 

--- a/libutil/exceptions/rethrowable_i.h
+++ b/libutil/exceptions/rethrowable_i.h
@@ -12,11 +12,11 @@ class rethrowable_i {
 public:
     /** \brief Virtual destructor
      **/
-    virtual ~rethrowable_i() throw();
+    virtual ~rethrowable_i() noexcept;
 
     /** \brief Clones this exception using operator new
      **/
-    virtual rethrowable_i *clone() const throw() = 0;
+    virtual rethrowable_i *clone() const noexcept = 0;
 
     /** \brief Rethrows this exception
      **/

--- a/libutil/exceptions/rethrowable_i.h
+++ b/libutil/exceptions/rethrowable_i.h
@@ -12,11 +12,11 @@ class rethrowable_i {
 public:
     /** \brief Virtual destructor
      **/
-    virtual ~rethrowable_i() throw();
+    virtual ~rethrowable_i();
 
     /** \brief Clones this exception using operator new
      **/
-    virtual rethrowable_i *clone() const throw() = 0;
+    virtual rethrowable_i *clone() const = 0;
 
     /** \brief Rethrows this exception
      **/

--- a/libutil/exceptions/util_exceptions.h
+++ b/libutil/exceptions/util_exceptions.h
@@ -22,25 +22,25 @@ public:
 	 **/
 	generic_exception(const char *ns, const char *clazz, const char *method,
 		const char *file, unsigned int line, const char *message)
-		throw() :
+		noexcept :
 		exception_base_t(ns, clazz, method, file, line, "generic_exception",
 			message) { };
 
 	/**	\brief Creates an exception that originates in libvmm
 	 **/
 	generic_exception(const char *clazz, const char *method, const char *file,
-		unsigned int line, const char *message) throw() :
+		unsigned int line, const char *message) noexcept :
 		exception_base_t("libutil", clazz, method, file, line,
 			"generic_exception", message) { };
 
 	/**	\brief Copy constructor
 	 **/
-	generic_exception(const generic_exception &e) throw() :
+	generic_exception(const generic_exception &e) noexcept :
 	    exception_base_t(e) { }
 
 	/**	\brief Virtual destructor
 	 **/
-	virtual ~generic_exception() throw() { };
+	virtual ~generic_exception() noexcept { };
 
 	//@}
 
@@ -62,25 +62,25 @@ public:
      **/
     threads_exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw() :
+        noexcept :
         exception_base_t(ns, clazz, method, file, line, "threads_exception",
             message) { };
 
     /** \brief Creates an exception that originates in libvmm
      **/
     threads_exception(const char *clazz, const char *method, const char *file,
-        unsigned int line, const char *message) throw() :
+        unsigned int line, const char *message) noexcept :
         exception_base_t("libutil", clazz, method, file, line,
             "threads_exception", message) { };
 
     /** \brief Copy constructor
      **/
-    threads_exception(const threads_exception &e) throw() :
+    threads_exception(const threads_exception &e) noexcept :
         exception_base_t(e) { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~threads_exception() throw() { };
+    virtual ~threads_exception() noexcept { };
 
     //@}
 
@@ -103,25 +103,25 @@ public:
      **/
     timings_exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw() :
+        noexcept :
         exception_base_t(ns, clazz, method, file, line, "timings_exception",
             message) { };
 
     /** \brief Creates an exception that originates in libvmm
      **/
     timings_exception(const char *clazz, const char *method, const char *file,
-        unsigned int line, const char *message) throw() :
+        unsigned int line, const char *message) noexcept :
         exception_base_t("libutil", clazz, method, file, line,
             "timings_exception", message) { };
 
     /** \brief Copy constructor
      **/
-    timings_exception(const timings_exception &e) throw() :
+    timings_exception(const timings_exception &e) noexcept :
         exception_base_t(e) { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~timings_exception() throw() { };
+    virtual ~timings_exception() noexcept { };
 
     //@}
 

--- a/libutil/exceptions/util_exceptions.h
+++ b/libutil/exceptions/util_exceptions.h
@@ -21,26 +21,25 @@ public:
 	/**	\brief Creates an exception
 	 **/
 	generic_exception(const char *ns, const char *clazz, const char *method,
-		const char *file, unsigned int line, const char *message)
-		throw() :
+		const char *file, unsigned int line, const char *message) :
 		exception_base_t(ns, clazz, method, file, line, "generic_exception",
 			message) { };
 
 	/**	\brief Creates an exception that originates in libvmm
 	 **/
 	generic_exception(const char *clazz, const char *method, const char *file,
-		unsigned int line, const char *message) throw() :
+		unsigned int line, const char *message) :
 		exception_base_t("libutil", clazz, method, file, line,
 			"generic_exception", message) { };
 
 	/**	\brief Copy constructor
 	 **/
-	generic_exception(const generic_exception &e) throw() :
+	generic_exception(const generic_exception &e) :
 	    exception_base_t(e) { }
 
 	/**	\brief Virtual destructor
 	 **/
-	virtual ~generic_exception() throw() { };
+	virtual ~generic_exception() { };
 
 	//@}
 
@@ -62,25 +61,25 @@ public:
      **/
     threads_exception(const char *ns, const char *clazz, const char *method,
         const char *file, unsigned int line, const char *message)
-        throw() :
+        :
         exception_base_t(ns, clazz, method, file, line, "threads_exception",
             message) { };
 
     /** \brief Creates an exception that originates in libvmm
      **/
     threads_exception(const char *clazz, const char *method, const char *file,
-        unsigned int line, const char *message) throw() :
+        unsigned int line, const char *message) :
         exception_base_t("libutil", clazz, method, file, line,
             "threads_exception", message) { };
 
     /** \brief Copy constructor
      **/
-    threads_exception(const threads_exception &e) throw() :
+    threads_exception(const threads_exception &e) :
         exception_base_t(e) { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~threads_exception() throw() { };
+    virtual ~threads_exception() { };
 
     //@}
 
@@ -102,26 +101,25 @@ public:
     /** \brief Creates an exception
      **/
     timings_exception(const char *ns, const char *clazz, const char *method,
-        const char *file, unsigned int line, const char *message)
-        throw() :
+        const char *file, unsigned int line, const char *message) :
         exception_base_t(ns, clazz, method, file, line, "timings_exception",
             message) { };
 
     /** \brief Creates an exception that originates in libvmm
      **/
     timings_exception(const char *clazz, const char *method, const char *file,
-        unsigned int line, const char *message) throw() :
+        unsigned int line, const char *message) :
         exception_base_t("libutil", clazz, method, file, line,
             "timings_exception", message) { };
 
     /** \brief Copy constructor
      **/
-    timings_exception(const timings_exception &e) throw() :
+    timings_exception(const timings_exception &e) :
         exception_base_t(e) { }
 
     /** \brief Virtual destructor
      **/
-    virtual ~timings_exception() throw() { };
+    virtual ~timings_exception() { };
 
     //@}
 

--- a/libutil/thread_pool/unknown_exception.C
+++ b/libutil/thread_pool/unknown_exception.C
@@ -6,18 +6,18 @@ namespace libutil {
 const char *unknown_exception::k_what = "libutil::unknown_exception";
 
 
-unknown_exception::~unknown_exception() throw() {
+unknown_exception::~unknown_exception() noexcept {
 
 }
 
 
-const char *unknown_exception::what() const throw() {
+const char *unknown_exception::what() const noexcept {
 
     return k_what;
 }
 
 
-rethrowable_i *unknown_exception::clone() const throw() {
+rethrowable_i *unknown_exception::clone() const noexcept {
 
     try {
         return new unknown_exception;

--- a/libutil/thread_pool/unknown_exception.C
+++ b/libutil/thread_pool/unknown_exception.C
@@ -6,18 +6,18 @@ namespace libutil {
 const char *unknown_exception::k_what = "libutil::unknown_exception";
 
 
-unknown_exception::~unknown_exception() throw() {
+unknown_exception::~unknown_exception() {
 
 }
 
 
-const char *unknown_exception::what() const throw() {
+const char *unknown_exception::what() const noexcept {
 
     return k_what;
 }
 
 
-rethrowable_i *unknown_exception::clone() const throw() {
+rethrowable_i *unknown_exception::clone() const {
 
     try {
         return new unknown_exception;

--- a/libutil/thread_pool/unknown_exception.h
+++ b/libutil/thread_pool/unknown_exception.h
@@ -18,15 +18,15 @@ private:
 public:
     /** \brief Virtual destructor
      **/
-    virtual ~unknown_exception() throw();
+    virtual ~unknown_exception() noexcept;
 
     /** \brief Returns the type of exception
      **/
-    virtual const char *what() const throw();
+    virtual const char *what() const noexcept;
 
     /** \brief Clones this exception using operator new
      **/
-    virtual rethrowable_i *clone() const throw();
+    virtual rethrowable_i *clone() const noexcept;
 
     /** \brief Rethrows this exception
      **/

--- a/libutil/thread_pool/unknown_exception.h
+++ b/libutil/thread_pool/unknown_exception.h
@@ -18,15 +18,15 @@ private:
 public:
     /** \brief Virtual destructor
      **/
-    virtual ~unknown_exception() throw();
+    virtual ~unknown_exception();
 
     /** \brief Returns the type of exception
      **/
-    virtual const char *what() const throw();
+    virtual const char *what() const noexcept;
 
     /** \brief Clones this exception using operator new
      **/
-    virtual rethrowable_i *clone() const throw();
+    virtual rethrowable_i *clone() const;
 
     /** \brief Rethrows this exception
      **/

--- a/libutil/threads/auto_lock.h
+++ b/libutil/threads/auto_lock.h
@@ -22,7 +22,7 @@ public:
         m_mtx.lock();
     }
 
-    ~auto_lock() throw() {
+    ~auto_lock() noexcept {
         m_mtx.unlock();
     }
 

--- a/libutil/threads/auto_lock.h
+++ b/libutil/threads/auto_lock.h
@@ -22,7 +22,7 @@ public:
         m_mtx.lock();
     }
 
-    ~auto_lock() throw() {
+    ~auto_lock() {
         m_mtx.unlock();
     }
 

--- a/tests/block_tensor/addition_schedule_test.C
+++ b/tests/block_tensor/addition_schedule_test.C
@@ -8,7 +8,7 @@
 namespace libtensor {
 
 
-void addition_schedule_test::perform() throw(libtest::test_exception) {
+void addition_schedule_test::perform() {
 
     test_1();
     test_2();
@@ -129,7 +129,7 @@ using namespace addition_schedule_test_ns;
 /** \test Tests the addition schedule for Sym(A) = Sym(B) = Sym(C) = 0.
         Order-two block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_1() throw(libtest::test_exception) {
+void addition_schedule_test::test_1() {
 
 //	static const char *testname = "addition_schedule_test::test_1()";
 
@@ -186,7 +186,7 @@ void addition_schedule_test::test_1() throw(libtest::test_exception) {
         S(+)2 = Sym(A) > Sym(B) = Sym(C) = 0.
         Order-two block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_2() throw(libtest::test_exception) {
+void addition_schedule_test::test_2() {
 
 //    static const char *testname = "addition_schedule_test::test_2()";
 
@@ -251,7 +251,7 @@ void addition_schedule_test::test_2() throw(libtest::test_exception) {
         0 = Sym(C) = Sym(A) < Sym(B) = Perm(+, 01).
         Order-two block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_3() throw(libtest::test_exception) {
+void addition_schedule_test::test_3() {
 
 //    static const char *testname = "addition_schedule_test::test_3()";
 
@@ -315,7 +315,7 @@ void addition_schedule_test::test_3() throw(libtest::test_exception) {
         Sym(A) = S(+)2, Sym(B) = S(-)2, Sym(C) = 0.
         Order-two block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_4() throw(libtest::test_exception) {
+void addition_schedule_test::test_4() {
 
 //    static const char *testname = "addition_schedule_test::test_4()";
 
@@ -382,7 +382,7 @@ void addition_schedule_test::test_4() throw(libtest::test_exception) {
 /** \test Tests the addition schedule for Sym(A) = Sym(B) = Sym(C) = S4.
         Order-four block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_5() throw(libtest::test_exception) {
+void addition_schedule_test::test_5() {
 
 //    static const char *testname = "addition_schedule_test::test_5()";
 
@@ -443,7 +443,7 @@ void addition_schedule_test::test_5() throw(libtest::test_exception) {
         S(+)4 = Sym(A) > Sym(B) = Sym(C) = S(+)2 * S(+)2.
         Order-four block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_6() throw(libtest::test_exception) {
+void addition_schedule_test::test_6() {
 
 //    static const char *testname = "addition_schedule_test::test_6()";
 
@@ -506,7 +506,7 @@ void addition_schedule_test::test_6() throw(libtest::test_exception) {
         S(+)4 = Sym(B) > Sym(A) = Sym(C) = S(+)2 * S(+)2.
         Order-four block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_7() throw(libtest::test_exception) {
+void addition_schedule_test::test_7() {
 
 //    static const char *testname = "addition_schedule_test::test_7()";
 
@@ -569,7 +569,7 @@ void addition_schedule_test::test_7() throw(libtest::test_exception) {
         S(+)4 = Sym(B) > Sym(C) = A4 < Sym(A) = S(-)4.
         Order-four block tensors with two blocks along each dimension.
  **/
-void addition_schedule_test::test_8() throw(libtest::test_exception) {
+void addition_schedule_test::test_8() {
 
 //    static const char *testname = "addition_schedule_test::test_8()";
 

--- a/tests/block_tensor/addition_schedule_test.h
+++ b/tests/block_tensor/addition_schedule_test.h
@@ -11,17 +11,17 @@ namespace libtensor {
  **/
 class addition_schedule_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
 
 };
 

--- a/tests/block_tensor/block_tensor_test.C
+++ b/tests/block_tensor/block_tensor_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void block_tensor_test::perform() throw(libtest::test_exception) {
+void block_tensor_test::perform() {
 
     test_nonzero_blocks_1();
     test_nonzero_blocks_2();

--- a/tests/block_tensor/block_tensor_test.h
+++ b/tests/block_tensor/block_tensor_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
  **/
 class block_tensor_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_nonzero_blocks_1();

--- a/tests/block_tensor/bto_contract2_bis_test.C
+++ b/tests/block_tensor/bto_contract2_bis_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void bto_contract2_bis_test::perform() throw(libtest::test_exception) {
+void bto_contract2_bis_test::perform() {
 
     test_1();
     test_2();
@@ -16,7 +16,7 @@ void bto_contract2_bis_test::perform() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_bis_test::test_1() throw(libtest::test_exception) {
+void bto_contract2_bis_test::test_1() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -63,7 +63,7 @@ void bto_contract2_bis_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_bis_test::test_2() throw(libtest::test_exception) {
+void bto_contract2_bis_test::test_2() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -120,7 +120,7 @@ void bto_contract2_bis_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_bis_test::test_3() throw(libtest::test_exception) {
+void bto_contract2_bis_test::test_3() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -181,7 +181,7 @@ void bto_contract2_bis_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_bis_test::test_4() throw(libtest::test_exception) {
+void bto_contract2_bis_test::test_4() {
 
     //
     //  c_ijkl = a_ijpq b_klpq
@@ -223,7 +223,7 @@ void bto_contract2_bis_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_bis_test::test_5() throw(libtest::test_exception) {
+void bto_contract2_bis_test::test_5() {
 
     //
     //  c_ijk = a_ipqr b_jpqrk
@@ -288,7 +288,7 @@ void bto_contract2_bis_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_bis_test::test_6() throw(libtest::test_exception) {
+void bto_contract2_bis_test::test_6() {
 
     //
     //  c_{ijab} = a_{ia} a_{jb}

--- a/tests/block_tensor/bto_contract2_bis_test.h
+++ b/tests/block_tensor/bto_contract2_bis_test.h
@@ -12,15 +12,15 @@ namespace libtensor {
 **/
 class bto_contract2_bis_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
 
 };
 

--- a/tests/block_tensor/bto_contract2_sym_test.C
+++ b/tests/block_tensor/bto_contract2_sym_test.C
@@ -11,7 +11,7 @@
 namespace libtensor {
 
 
-void bto_contract2_sym_test::perform() throw(libtest::test_exception) {
+void bto_contract2_sym_test::perform() {
 
     test_1();
     test_2();
@@ -20,7 +20,7 @@ void bto_contract2_sym_test::perform() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_sym_test::test_1() throw(libtest::test_exception) {
+void bto_contract2_sym_test::test_1() {
 
     static const char *testname = "bto_contract2_sym_test::test_1()";
 
@@ -75,7 +75,7 @@ void bto_contract2_sym_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_sym_test::test_2() throw(libtest::test_exception) {
+void bto_contract2_sym_test::test_2() {
 
     //
     //  c_ijk = a_ipqr b_jpqrk
@@ -153,7 +153,7 @@ void bto_contract2_sym_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_sym_test::test_3() throw(libtest::test_exception) {
+void bto_contract2_sym_test::test_3() {
 
     //
     //  c_ijpq = a_ijpr b_qr
@@ -232,7 +232,7 @@ void bto_contract2_sym_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void bto_contract2_sym_test::test_4() throw(libtest::test_exception) {
+void bto_contract2_sym_test::test_4() {
 
     //
     //  c_ijkl = a_klab b_klab

--- a/tests/block_tensor/bto_contract2_sym_test.h
+++ b/tests/block_tensor/bto_contract2_sym_test.h
@@ -12,13 +12,13 @@ namespace libtensor {
 **/
 class bto_contract2_sym_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
 
 };
 

--- a/tests/block_tensor/btod_add_test.C
+++ b/tests/block_tensor/btod_add_test.C
@@ -13,7 +13,7 @@
 
 namespace libtensor {
 
-void btod_add_test::perform() throw(libtest::test_exception) {
+void btod_add_test::perform() {
 
     allocator<double>::init();
 
@@ -60,7 +60,7 @@ void btod_add_test::perform() throw(libtest::test_exception) {
 }
 
 void btod_add_test::test_1(double ca1, double ca2)
-    throw(libtest::test_exception) {
+    {
 
     //
     //  Arg 1: One non-zero block
@@ -123,7 +123,7 @@ void btod_add_test::test_1(double ca1, double ca2)
 
 
 void btod_add_test::test_2(double ca1, double ca2, double cs)
-    throw(libtest::test_exception) {
+    {
 
     //
     //  Arg 1: One non-zero block
@@ -189,7 +189,7 @@ void btod_add_test::test_2(double ca1, double ca2, double cs)
 
 
 void btod_add_test::test_3(double ca1, double ca2)
-    throw(libtest::test_exception) {
+    {
 
     //
     //  Arg 1: Non-zero off-diagonal blocks, permutational symmetry
@@ -262,7 +262,7 @@ void btod_add_test::test_3(double ca1, double ca2)
 
 
 void btod_add_test::test_4(double ca1, double ca2, double ca3, double ca4)
-    throw(libtest::test_exception) {
+    {
 
     //
     //  Arg 1: One non-zero off-diagonal block [0,0,0,1]
@@ -365,7 +365,7 @@ void btod_add_test::test_4(double ca1, double ca2, double ca3, double ca4)
 }
 
 
-void btod_add_test::test_5() throw(libtest::test_exception) {
+void btod_add_test::test_5() {
 
     //
     //  Tests addition to zero vs. overwrite (single arguments)
@@ -400,7 +400,7 @@ void btod_add_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void btod_add_test::test_6() throw(libtest::test_exception) {
+void btod_add_test::test_6() {
 
     //
     //  Tests addition to zero vs. overwrite (multiple arguments)
@@ -440,7 +440,7 @@ void btod_add_test::test_6() throw(libtest::test_exception) {
 
 /** \brief Tests a particular block %index space that is causing a problem
  **/
-void btod_add_test::test_7() throw(libtest::test_exception) {
+void btod_add_test::test_7() {
 
     static const char *testname = "btod_add_test::test_7()";
 
@@ -504,7 +504,7 @@ void btod_add_test::test_7() throw(libtest::test_exception) {
 /** \brief Tests \f$ B_{iajb} = B_{iajb} + A_{ijab} qquad
         A \in S^{-}_2 \times S^{-}_2 \f$
  **/
-void btod_add_test::test_8() throw(libtest::test_exception) {
+void btod_add_test::test_8() {
 
     static const char *testname = "btod_add_test::test_8()";
 
@@ -574,7 +574,7 @@ void btod_add_test::test_8() throw(libtest::test_exception) {
 /** \brief Tests \f$ B_{jkab} = B_{jkab} + A_{kajb} qquad
         A \in S^{-}_2 \times S^{-}_2 \f$
  **/
-void btod_add_test::test_9() throw(libtest::test_exception) {
+void btod_add_test::test_9() {
 
     static const char *testname = "btod_add_test::test_9()";
 
@@ -637,7 +637,7 @@ void btod_add_test::test_9() throw(libtest::test_exception) {
 }
 
 
-void btod_add_test::test_10(double d) throw(libtest::test_exception) {
+void btod_add_test::test_10(double d) {
 
     std::ostringstream tnss;
     tnss << "btod_add_test::test_10(" << d << ")";
@@ -722,7 +722,7 @@ void btod_add_test::test_10(double d) throw(libtest::test_exception) {
 }
 
 
-void btod_add_test::test_11(bool sign) throw(libtest::test_exception) {
+void btod_add_test::test_11(bool sign) {
 
     std::ostringstream tnss;
     tnss << "btod_add_test::test_11(" << (sign ? '+' : '-') << ")";
@@ -801,7 +801,7 @@ void btod_add_test::test_11(bool sign) throw(libtest::test_exception) {
 }
 
 
-void btod_add_test::test_exc() throw(libtest::test_exception) {
+void btod_add_test::test_exc() {
     /*
     libtensor::index<2> i1, i2; i2[0] = 1; i2[1] = 2;
     dimensions<2> dims_ia(index_range<2>(i1, i2));

--- a/tests/block_tensor/btod_add_test.h
+++ b/tests/block_tensor/btod_add_test.h
@@ -11,27 +11,27 @@ namespace libtensor {
  **/
 class btod_add_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(double ca1, double ca2) throw(libtest::test_exception);
+    void test_1(double ca1, double ca2);
     void test_2(double ca1, double ca2, double cs)
-        throw(libtest::test_exception);
-    void test_3(double ca1, double ca2) throw(libtest::test_exception);
+       ;
+    void test_3(double ca1, double ca2);
     void test_4(double ca1, double ca2, double ca3, double ca4)
-        throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
-    void test_10(double d) throw(libtest::test_exception);
-    void test_11(bool sign) throw(libtest::test_exception);
+       ;
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
+    void test_9();
+    void test_10(double d);
+    void test_11(bool sign);
 
     /** \brief Tests if exceptions are thrown when the tensors have
             different dimensions
     **/
-    void test_exc() throw(libtest::test_exception);
+    void test_exc();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_apply_test.C
+++ b/tests/block_tensor/btod_apply_test.C
@@ -46,7 +46,7 @@ struct exp_functor {
 
 } // namespace btod_apply_test_ns
 
-void btod_apply_test::perform() throw(libtest::test_exception) {
+void btod_apply_test::perform() {
 
     allocator<double>::init();
 
@@ -96,7 +96,7 @@ void btod_apply_test::perform() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = sin(a_{ij}) \f$, zero tensor to zero tensor
  **/
-void btod_apply_test::test_zero_1() throw(libtest::test_exception) {
+void btod_apply_test::test_zero_1() {
 
     static const char *testname = "btod_apply_test::test_zero_1()";
 
@@ -143,7 +143,7 @@ void btod_apply_test::test_zero_1() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = sin(a_{ij}) \f$, zero tensor
  **/
-void btod_apply_test::test_zero_2() throw(libtest::test_exception) {
+void btod_apply_test::test_zero_2() {
 
     static const char *testname = "btod_apply_test::test_zero_2()";
 
@@ -197,7 +197,7 @@ void btod_apply_test::test_zero_2() throw(libtest::test_exception) {
 
      !!!Test currently deactivated!!!
  **/
-void btod_apply_test::test_zero_3() throw(libtest::test_exception) {
+void btod_apply_test::test_zero_3() {
 
     static const char *testname = "btod_apply_test::test_zero_3()";
 
@@ -249,7 +249,7 @@ void btod_apply_test::test_zero_3() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = sin(a_{ij}) \f$, no symmetry, no blocks
  **/
-void btod_apply_test::test_nosym_1() throw(libtest::test_exception) {
+void btod_apply_test::test_nosym_1() {
 
     static const char *testname = "btod_apply_test::test_nosym_1()";
 
@@ -293,7 +293,7 @@ void btod_apply_test::test_nosym_1() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = sin(2 a_{ji}) \f$, no symmetry, no blocks
  **/
-void btod_apply_test::test_nosym_2() throw(libtest::test_exception) {
+void btod_apply_test::test_nosym_2() {
 
     static const char *testname = "btod_apply_test::test_nosym_2()";
 
@@ -340,7 +340,7 @@ void btod_apply_test::test_nosym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = sin(a_{ij}) \f$, no symmetry, 3 blocks along each
         direction
  **/
-void btod_apply_test::test_nosym_3() throw(libtest::test_exception) {
+void btod_apply_test::test_nosym_3() {
 
     static const char *testname = "btod_apply_test::test_nosym_3()";
 
@@ -388,7 +388,7 @@ void btod_apply_test::test_nosym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = sin(2 a_{ji}) \f$, no symmetry, 3 blocks along each
         direction
  **/
-void btod_apply_test::test_nosym_4() throw(libtest::test_exception) {
+void btod_apply_test::test_nosym_4() {
 
     static const char *testname = "btod_apply_test::test_nosym_4()";
 
@@ -439,7 +439,7 @@ void btod_apply_test::test_nosym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = sin(a_{ij}) \f$, perm symmetry, 3 blocks along each
         direction
  **/
-void btod_apply_test::test_sym_1() throw(libtest::test_exception) {
+void btod_apply_test::test_sym_1() {
 
     static const char *testname = "btod_apply_test::test_sym_1()";
 
@@ -493,7 +493,7 @@ void btod_apply_test::test_sym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = sin(-2 a_{ji}) \f$, perm antisymmetry,
         3 blocks along each direction
  **/
-void btod_apply_test::test_sym_2() throw(libtest::test_exception) {
+void btod_apply_test::test_sym_2() {
 
     static const char *testname = "btod_apply_test::test_sym_2()";
 
@@ -548,7 +548,7 @@ void btod_apply_test::test_sym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijk} = sin(0.3 a_{kji}) \f$, perm symmetry, 3 blocks along
         each direction
  **/
-void btod_apply_test::test_sym_3() throw(libtest::test_exception) {
+void btod_apply_test::test_sym_3() {
 
     static const char *testname = "btod_apply_test::test_sym_3()";
 
@@ -615,7 +615,7 @@ void btod_apply_test::test_sym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = sin(-a_{ijkl}) \f$, perm symmetry,
         dim(ij)=10, dim(kl)=12, blocks, non-zero initial B
  **/
-void btod_apply_test::test_sym_4() throw(libtest::test_exception) {
+void btod_apply_test::test_sym_4() {
 
     static const char *testname = "btod_apply_test::test_sym_4()";
 
@@ -684,7 +684,7 @@ void btod_apply_test::test_sym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = exp(-a_{ij}) \f$, perm symmetry (+), label symmetry
         dim(ij)=10, blocks, non-zero initial B
  **/
-void btod_apply_test::test_sym_5() throw(libtest::test_exception) {
+void btod_apply_test::test_sym_5() {
 
     static const char *testname = "btod_apply_test::test_sym_5()";
 
@@ -785,7 +785,7 @@ void btod_apply_test::test_sym_5() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = b_{ij} + sin(a_{ij}) \f$, no symmetry, no blocks
  **/
-void btod_apply_test::test_add_nosym_1() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nosym_1() {
 
     static const char *testname = "btod_apply_test::test_add_nosym_1()";
 
@@ -831,7 +831,7 @@ void btod_apply_test::test_add_nosym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + 2 sin(a_{ji}) \f$, no symmetry,
         3 blocks along each direction
  **/
-void btod_apply_test::test_add_nosym_2() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nosym_2() {
 
     static const char *testname = "btod_apply_test::test_add_nosym_2()";
 
@@ -884,7 +884,7 @@ void btod_apply_test::test_add_nosym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + sin(2 a_{ijkl}) \f$, no symmetry,
         dim(ij)=10, dim(kl)=12, blocks
  **/
-void btod_apply_test::test_add_nosym_3() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nosym_3() {
 
     static const char *testname = "btod_apply_test::test_add_nosym_3()";
 
@@ -940,7 +940,7 @@ void btod_apply_test::test_add_nosym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + 2 sin(a_{ji}) \f$, no symmetry,
         3 blocks along each direction, empty initial B
  **/
-void btod_apply_test::test_add_nosym_4() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nosym_4() {
 
     static const char *testname = "btod_apply_test::test_add_nosym_4()";
 
@@ -992,7 +992,7 @@ void btod_apply_test::test_add_nosym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + sin(a_{ij}) \f$, equal perm symmetry,
         3 blocks along each direction
  **/
-void btod_apply_test::test_add_eqsym_1() throw(libtest::test_exception) {
+void btod_apply_test::test_add_eqsym_1() {
 
     static const char *testname = "btod_apply_test::test_add_eqsym_1()";
 
@@ -1046,7 +1046,7 @@ void btod_apply_test::test_add_eqsym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} - sin(a_{ji}) \f$, equal perm antisymmetry,
         3 blocks along each direction
  **/
-void btod_apply_test::test_add_eqsym_2() throw(libtest::test_exception) {
+void btod_apply_test::test_add_eqsym_2() {
 
     static const char *testname = "btod_apply_test::test_add_eqsym_2()";
 
@@ -1104,7 +1104,7 @@ void btod_apply_test::test_add_eqsym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijk} = b_{ijk} + 0.5 sin(1.5 a_{kji}) \f$, equal perm symmetry,
         3 blocks along each direction
  **/
-void btod_apply_test::test_add_eqsym_3() throw(libtest::test_exception) {
+void btod_apply_test::test_add_eqsym_3() {
 
     static const char *testname = "btod_copy_test::test_add_eqsym_3()";
 
@@ -1176,7 +1176,7 @@ void btod_apply_test::test_add_eqsym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + sin(2 a_{ijkl}) \f$, equal perm symmetry,
         dim(ij)=10, dim(kl)=12, blocks
  **/
-void btod_apply_test::test_add_eqsym_4() throw(libtest::test_exception) {
+void btod_apply_test::test_add_eqsym_4() {
 
     static const char *testname = "btod_apply_test::test_add_eqsym_4()";
 
@@ -1245,7 +1245,7 @@ void btod_apply_test::test_add_eqsym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ikjl} = b_{ikjl} + 0.5 sin(a_{ijkl}) \f$,
         equal perm antisymmetry, dim(ij)=10, dim(kl)=12, blocks
  **/
-void btod_apply_test::test_add_eqsym_5() throw(libtest::test_exception) {
+void btod_apply_test::test_add_eqsym_5() {
 
     static const char *testname = "btod_apply_test::test_add_eqsym_5()";
 
@@ -1318,7 +1318,7 @@ void btod_apply_test::test_add_eqsym_5() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + sin(a_{ij}) \f$, unequal perm symmetry,
         Sym(A) > Sym(B) = Sym(B') = Sym(0), blocks
  **/
-void btod_apply_test::test_add_nesym_1() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_1() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_1()";
 
@@ -1371,7 +1371,7 @@ void btod_apply_test::test_add_nesym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + sin(a_{ij}) \f$, unequal perm symmetry,
         Sym(B) > Sym(A) = Sym(B') = Sym(0), blocks
  **/
-void btod_apply_test::test_add_nesym_2() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_2() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_2()";
 
@@ -1424,7 +1424,7 @@ void btod_apply_test::test_add_nesym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 sin(a_{ijkl}) \f$, unequal perm symmetry,
         Sym(A) > Sym(B) = Sym(B') != Sym(0), blocks
  **/
-void btod_apply_test::test_add_nesym_3() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_3() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_3()";
 
@@ -1492,7 +1492,7 @@ void btod_apply_test::test_add_nesym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 sin(a_{ijkl}) \f$, unequal perm
         symmetry, Sym(B) > Sym(A) = Sym(B') != Sym(0), blocks
  **/
-void btod_apply_test::test_add_nesym_4() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_4() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_4()";
 
@@ -1560,7 +1560,7 @@ void btod_apply_test::test_add_nesym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 sin(a_{ijkl}) \f$,
         unequal perm symmetry, blocks
  **/
-void btod_apply_test::test_add_nesym_5() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_5() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_5()";
 
@@ -1628,7 +1628,7 @@ void btod_apply_test::test_add_nesym_5() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 sin(a_{ijkl}) \f$,
         unequal perm symmetry, sparse block structure
  **/
-void btod_apply_test::test_add_nesym_5_sp() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_5_sp() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_5_sp()";
 
@@ -1711,7 +1711,7 @@ void btod_apply_test::test_add_nesym_5_sp() throw(libtest::test_exception) {
 /** \test \f$ b_{lkji} = b_{lkji} - 0.1 sin(a_{ijkl}) \f$, unequal mixed perm
         symmetry and antisymmetry, blocks
  **/
-void btod_apply_test::test_add_nesym_6() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_6() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_6()";
 
@@ -1786,7 +1786,7 @@ void btod_apply_test::test_add_nesym_6() throw(libtest::test_exception) {
         C[0,1,2,0] = A[0,1,2,0] + B[0,1,0,2],
         A[0,0,1,2] = 0
  **/
-void btod_apply_test::test_add_nesym_7_sp1() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_7_sp1() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_7_sp1()";
 
@@ -1861,7 +1861,7 @@ void btod_apply_test::test_add_nesym_7_sp1() throw(libtest::test_exception) {
         C[0,1,0,2] = B[0,1,0,2],
         C[0,1,2,0] = B[0,1,0,2],
  **/
-void btod_apply_test::test_add_nesym_7_sp2() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_7_sp2() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_7_sp2()";
 
@@ -1936,7 +1936,7 @@ void btod_apply_test::test_add_nesym_7_sp2() throw(libtest::test_exception) {
         C[0,1,2,0] = A[0,1,0,2] + B[0,1,2,0],
         B[0,0,1,2] = 0
  **/
-void btod_apply_test::test_add_nesym_7_sp3() throw(libtest::test_exception) {
+void btod_apply_test::test_add_nesym_7_sp3() {
 
     static const char *testname = "btod_apply_test::test_add_nesym_7_sp3()";
 

--- a/tests/block_tensor/btod_apply_test.h
+++ b/tests/block_tensor/btod_apply_test.h
@@ -11,40 +11,40 @@ namespace libtensor {
  **/
 class btod_apply_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_zero_1() throw(libtest::test_exception);
-    void test_zero_2() throw(libtest::test_exception);
-    void test_zero_3() throw(libtest::test_exception);
-    void test_nosym_1() throw(libtest::test_exception);
-    void test_nosym_2() throw(libtest::test_exception);
-    void test_nosym_3() throw(libtest::test_exception);
-    void test_nosym_4() throw(libtest::test_exception);
-    void test_sym_1() throw(libtest::test_exception);
-    void test_sym_2() throw(libtest::test_exception);
-    void test_sym_3() throw(libtest::test_exception);
-    void test_sym_4() throw(libtest::test_exception);
-    void test_sym_5() throw(libtest::test_exception);
-    void test_add_nosym_1() throw(libtest::test_exception);
-    void test_add_nosym_2() throw(libtest::test_exception);
-    void test_add_nosym_3() throw(libtest::test_exception);
-    void test_add_nosym_4() throw(libtest::test_exception);
-    void test_add_eqsym_1() throw(libtest::test_exception);
-    void test_add_eqsym_2() throw(libtest::test_exception);
-    void test_add_eqsym_3() throw(libtest::test_exception);
-    void test_add_eqsym_4() throw(libtest::test_exception);
-    void test_add_eqsym_5() throw(libtest::test_exception);
-    void test_add_nesym_1() throw(libtest::test_exception);
-    void test_add_nesym_2() throw(libtest::test_exception);
-    void test_add_nesym_3() throw(libtest::test_exception);
-    void test_add_nesym_4() throw(libtest::test_exception);
-    void test_add_nesym_5() throw(libtest::test_exception);
-    void test_add_nesym_5_sp() throw(libtest::test_exception);
-    void test_add_nesym_6() throw(libtest::test_exception);
-    void test_add_nesym_7_sp1() throw(libtest::test_exception);
-    void test_add_nesym_7_sp2() throw(libtest::test_exception);
-    void test_add_nesym_7_sp3() throw(libtest::test_exception);
+    void test_zero_1();
+    void test_zero_2();
+    void test_zero_3();
+    void test_nosym_1();
+    void test_nosym_2();
+    void test_nosym_3();
+    void test_nosym_4();
+    void test_sym_1();
+    void test_sym_2();
+    void test_sym_3();
+    void test_sym_4();
+    void test_sym_5();
+    void test_add_nosym_1();
+    void test_add_nosym_2();
+    void test_add_nosym_3();
+    void test_add_nosym_4();
+    void test_add_eqsym_1();
+    void test_add_eqsym_2();
+    void test_add_eqsym_3();
+    void test_add_eqsym_4();
+    void test_add_eqsym_5();
+    void test_add_nesym_1();
+    void test_add_nesym_2();
+    void test_add_nesym_3();
+    void test_add_nesym_4();
+    void test_add_nesym_5();
+    void test_add_nesym_5_sp();
+    void test_add_nesym_6();
+    void test_add_nesym_7_sp1();
+    void test_add_nesym_7_sp2();
+    void test_add_nesym_7_sp3();
 
 };
 

--- a/tests/block_tensor/btod_compare_test.C
+++ b/tests/block_tensor/btod_compare_test.C
@@ -15,7 +15,7 @@
 namespace libtensor {
 
 
-void btod_compare_test::perform() throw(libtest::test_exception) {
+void btod_compare_test::perform() {
 
     allocator<double>::init();
     try {
@@ -44,7 +44,7 @@ void btod_compare_test::perform() throw(libtest::test_exception) {
 
 /** \test Comparison of a block %tensor with itself
  **/
-void btod_compare_test::test_1() throw(libtest::test_exception) {
+void btod_compare_test::test_1() {
 
     static const char *testname = "btod_compare_test::test_1()";
 
@@ -80,7 +80,7 @@ void btod_compare_test::test_1() throw(libtest::test_exception) {
 
 /** \test Comparison of two block %tensors with different number of orbits
  **/
-void btod_compare_test::test_2a() throw(libtest::test_exception) {
+void btod_compare_test::test_2a() {
 
     static const char *testname = "btod_compare_test::test_2a()";
 
@@ -123,7 +123,7 @@ void btod_compare_test::test_2a() throw(libtest::test_exception) {
 
 /** \test Comparison of two block %tensors with different number of orbits
  **/
-void btod_compare_test::test_2b() throw(libtest::test_exception) {
+void btod_compare_test::test_2b() {
 
     static const char *testname = "btod_compare_test::test_2b()";
 
@@ -167,7 +167,7 @@ void btod_compare_test::test_2b() throw(libtest::test_exception) {
 /** \test Comparison of two block %tensors with the same number of orbits,
         but different set of canonical indexes
  **/
-void btod_compare_test::test_3a() throw(libtest::test_exception) {
+void btod_compare_test::test_3a() {
 
     static const char *testname = "btod_compare_test::test_3a()";
 
@@ -224,7 +224,7 @@ void btod_compare_test::test_3a() throw(libtest::test_exception) {
 /** \test Comparison of two block %tensors with the same number of orbits,
         but different set of canonical indexes
  **/
-void btod_compare_test::test_3b() throw(libtest::test_exception) {
+void btod_compare_test::test_3b() {
 
     static const char *testname = "btod_compare_test::test_3b()";
 
@@ -281,7 +281,7 @@ void btod_compare_test::test_3b() throw(libtest::test_exception) {
 /** \test Comparison of two block %tensors with the same number of orbits,
         but different set of canonical indexes
  **/
-void btod_compare_test::test_4a() throw(libtest::test_exception) {
+void btod_compare_test::test_4a() {
 
     static const char *testname = "btod_compare_test::test_4a()";
 
@@ -342,7 +342,7 @@ void btod_compare_test::test_4a() throw(libtest::test_exception) {
 /** \test Comparison of two block %tensors with the same number of orbits,
         but different set of canonical indexes
  **/
-void btod_compare_test::test_4b() throw(libtest::test_exception) {
+void btod_compare_test::test_4b() {
 
     static const char *testname = "btod_compare_test::test_4b()";
 
@@ -403,7 +403,7 @@ void btod_compare_test::test_4b() throw(libtest::test_exception) {
 /** \test Comparison of two block %tensors with the same number of orbits,
         same canonical indexes, but different block transformations
  **/
-void btod_compare_test::test_5a() throw(libtest::test_exception) {
+void btod_compare_test::test_5a() {
 
     static const char *testname = "btod_compare_test::test_5a()";
 
@@ -462,7 +462,7 @@ void btod_compare_test::test_5a() throw(libtest::test_exception) {
 /** \test Comparison of two block %tensors with the same number of orbits,
         same canonical indexes, but different block transformations
  **/
-void btod_compare_test::test_5b() throw(libtest::test_exception) {
+void btod_compare_test::test_5b() {
 
     static const char *testname = "btod_compare_test::test_5b()";
 
@@ -521,7 +521,7 @@ void btod_compare_test::test_5b() throw(libtest::test_exception) {
 /** \test Comparison of two block %tensors with the same orbits and
         transformations, but symmetries set up differently
  **/
-void btod_compare_test::test_6() throw(libtest::test_exception) {
+void btod_compare_test::test_6() {
 
     static const char *testname = "btod_compare_test::test_6()";
 
@@ -572,7 +572,7 @@ void btod_compare_test::test_6() throw(libtest::test_exception) {
 /** \test Comparison of two block tensors with the same orbits and
         transformations, but symmetries set up differently
  **/
-void btod_compare_test::test_7() throw(libtest::test_exception) {
+void btod_compare_test::test_7() {
 
     static const char *testname = "btod_compare_test::test_7()";
 
@@ -624,7 +624,7 @@ void btod_compare_test::test_7() throw(libtest::test_exception) {
 }
 
 
-void btod_compare_test::test_exc() throw(libtest::test_exception) {
+void btod_compare_test::test_exc() {
     typedef libtensor::index<2> index_t;
     typedef index_range<2> index_range_t;
     typedef dimensions<2> dimensions_t;
@@ -684,7 +684,7 @@ void btod_compare_test::test_exc() throw(libtest::test_exception) {
 }
 
 
-void btod_compare_test::test_operation() throw(libtest::test_exception) {
+void btod_compare_test::test_operation() {
 
     static const char *testname = "btod_compare_test::test_operation()";
 

--- a/tests/block_tensor/btod_compare_test.h
+++ b/tests/block_tensor/btod_compare_test.h
@@ -11,29 +11,29 @@ namespace libtensor {
 **/
 class btod_compare_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2a() throw(libtest::test_exception);
-    void test_2b() throw(libtest::test_exception);
-    void test_3a() throw(libtest::test_exception);
-    void test_3b() throw(libtest::test_exception);
-    void test_4a() throw(libtest::test_exception);
-    void test_4b() throw(libtest::test_exception);
-    void test_5a() throw(libtest::test_exception);
-    void test_5b() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
+    void test_1();
+    void test_2a();
+    void test_2b();
+    void test_3a();
+    void test_3b();
+    void test_4a();
+    void test_4b();
+    void test_5a();
+    void test_5b();
+    void test_6();
+    void test_7();
 
     /** \brief Tests if an exception is throws when the tensors have
             different dimensions
      **/
-    void test_exc() throw(libtest::test_exception);
+    void test_exc();
 
     /** \brief Tests the operation
     **/
-    void test_operation() throw(libtest::test_exception);
+    void test_operation();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_contract2_test.C
+++ b/tests/block_tensor/btod_contract2_test.C
@@ -20,7 +20,7 @@
 namespace libtensor {
 
 
-void btod_contract2_test::perform() throw(libtest::test_exception) {
+void btod_contract2_test::perform() {
 
     allocator<double>::init();
 
@@ -101,7 +101,7 @@ void btod_contract2_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_bis_1() throw(libtest::test_exception) {
+void btod_contract2_test::test_bis_1() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -152,7 +152,7 @@ void btod_contract2_test::test_bis_1() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_bis_2() throw(libtest::test_exception) {
+void btod_contract2_test::test_bis_2() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -213,7 +213,7 @@ void btod_contract2_test::test_bis_2() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_bis_3() throw(libtest::test_exception) {
+void btod_contract2_test::test_bis_3() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -278,7 +278,7 @@ void btod_contract2_test::test_bis_3() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_bis_4() throw(libtest::test_exception) {
+void btod_contract2_test::test_bis_4() {
 
     //
     //  c_ijkl = a_ijpq b_klpq
@@ -323,7 +323,7 @@ void btod_contract2_test::test_bis_4() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_bis_5() throw(libtest::test_exception) {
+void btod_contract2_test::test_bis_5() {
 
     //
     //  c_ijk = a_ipqr b_jpqrk
@@ -398,7 +398,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is zero, b is non-zero. Initially, c is zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_test::test_zeroblk_1() throw(libtest::test_exception) {
+void btod_contract2_test::test_zeroblk_1() {
 
     static const char *testname = "btod_contract2_test::test_zeroblk_1()";
 
@@ -451,7 +451,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is zero, b is non-zero. Initially, c is non-zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_test::test_zeroblk_2() throw(libtest::test_exception) {
+void btod_contract2_test::test_zeroblk_2() {
 
     static const char *testname = "btod_contract2_test::test_zeroblk_2()";
 
@@ -505,7 +505,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is non-zero, b is zero. Initially, c is zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_test::test_zeroblk_3() throw(libtest::test_exception) {
+void btod_contract2_test::test_zeroblk_3() {
 
     static const char *testname = "btod_contract2_test::test_zeroblk_3()";
 
@@ -558,7 +558,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is non-zero, b is zero. Initially, c is non-zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_test::test_zeroblk_4() throw(libtest::test_exception) {
+void btod_contract2_test::test_zeroblk_4() {
 
     static const char *testname = "btod_contract2_test::test_zeroblk_4()";
 
@@ -613,7 +613,7 @@ Only diagonal blocks in a and b are non-zero. Initially, c is zero.
 The result c is expected to have diagonal blocks non-zero and
 off-diagonal blocks zero.
  **/
-void btod_contract2_test::test_zeroblk_5() throw(libtest::test_exception) {
+void btod_contract2_test::test_zeroblk_5() {
 
     static const char *testname = "btod_contract2_test::test_zeroblk_5()";
 
@@ -686,7 +686,7 @@ Only diagonal blocks in a and b are non-zero. Initially, c is non-zero.
 The result c is expected to have diagonal blocks non-zero and
 off-diagonal blocks zero.
  **/
-void btod_contract2_test::test_zeroblk_6() throw(libtest::test_exception) {
+void btod_contract2_test::test_zeroblk_6() {
 
     static const char *testname = "btod_contract2_test::test_zeroblk_6()";
 
@@ -753,7 +753,7 @@ void btod_contract2_test::test_zeroblk_6() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_1() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_1() {
 
     //
     //  c_ijkl = a_ijpq b_klpq
@@ -822,7 +822,7 @@ void btod_contract2_test::test_contr_1() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_2() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_2() {
 
     //
     //  c_ikjl = a_ijpq b_klqp
@@ -892,7 +892,7 @@ void btod_contract2_test::test_contr_2() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_3() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_3() {
 
     //
     //  c_ijkl = a_ijpq b_pqkl
@@ -974,7 +974,7 @@ void btod_contract2_test::test_contr_3() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_4() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_4() {
 
     //
     //  c_ijkl = a_ijpq b_pqkl
@@ -1069,7 +1069,7 @@ void btod_contract2_test::test_contr_4() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_5() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_5() {
 
     //
     //  c_ijkl = c_ijkl + a_ijpq b_pqkl
@@ -1171,7 +1171,7 @@ void btod_contract2_test::test_contr_5() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_6() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_6() {
 
     //
     //  c_ijkl = c_ijkl + a_ijpq b_pqkl
@@ -1272,7 +1272,7 @@ void btod_contract2_test::test_contr_6() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_7() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_7() {
 
     //
     //  c_ijkl = a_pi b_jklp
@@ -1350,7 +1350,7 @@ void btod_contract2_test::test_contr_7() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_8() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_8() {
 
     //
     //  c_ijkl = a_pi b_jklp
@@ -1418,7 +1418,7 @@ void btod_contract2_test::test_contr_8() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_9() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_9() {
 
     //
     //  c_ijkl = - a_pi b_jklp
@@ -1485,7 +1485,7 @@ void btod_contract2_test::test_contr_9() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_10() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_10() {
 
     //
     //  c_ijkl = - a_pi b_jklp
@@ -1543,7 +1543,7 @@ void btod_contract2_test::test_contr_10() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_11() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_11() {
 
     //
     //  c_ijkl = a_ij b_kl
@@ -1605,7 +1605,7 @@ void btod_contract2_test::test_contr_11() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_12() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_12() {
 
     //
     //  c_ijkl = a_ij b_lk
@@ -1669,7 +1669,7 @@ void btod_contract2_test::test_contr_12() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_13() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_13() {
 
     //
     //  c_ij = a_kijl b_kl
@@ -2488,7 +2488,7 @@ throw(libtest::test_exception) {
     No symmetry in A, partition symmetry in B.
     Zero non-diagonal blocks.
  **/
-void btod_contract2_test::test_contr_21() throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_21() {
 
     std::ostringstream ss;
     ss << "btod_contract2_test::test_contr_21()";

--- a/tests/block_tensor/btod_contract2_test.C
+++ b/tests/block_tensor/btod_contract2_test.C
@@ -1735,8 +1735,7 @@ void btod_contract2_test::test_contr_13() {
 }
 
 
-void btod_contract2_test::test_contr_14(double c)
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_14(double c) {
 
     //
     //  c_ijkl = a_ijmn b_klmn
@@ -1810,8 +1809,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_15(double c)
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_15(double c) {
 
     //
     //  c_ijkl = a_ijmn b_klmn
@@ -1890,8 +1888,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_16(double c)
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_16(double c) {
 
     //
     //  c_iabc = a_kcad b_ikbd
@@ -1977,8 +1974,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_17(double c)
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_17(double c) {
 
     //
     //  c_ij = a_jkab b_ikab
@@ -2074,8 +2070,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_18(double c)
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_18(double c) {
 
     //
     //  c_ij = a_jkab b_iakb
@@ -2166,8 +2161,7 @@ throw(libtest::test_exception) {
     }
 }
 
-void btod_contract2_test::test_contr_19()
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_19() {
 
     //
     //  c_ijab = a_ijkl b_klab
@@ -2296,8 +2290,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_test::test_contr_20a()
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_20a() {
 
     //
     //  c_iy = a_ix b_xy
@@ -2378,8 +2371,7 @@ throw(libtest::test_exception) {
 
 }
 
-void btod_contract2_test::test_contr_20b()
-throw(libtest::test_exception) {
+void btod_contract2_test::test_contr_20b() {
 
     //
     //  c_iy = a_ix b_xy

--- a/tests/block_tensor/btod_contract2_test.h
+++ b/tests/block_tensor/btod_contract2_test.h
@@ -12,44 +12,44 @@ namespace libtensor {
 **/
 class btod_contract2_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_bis_1() throw(libtest::test_exception);
-    void test_bis_2() throw(libtest::test_exception);
-    void test_bis_3() throw(libtest::test_exception);
-    void test_bis_4() throw(libtest::test_exception);
-    void test_bis_5() throw(libtest::test_exception);
+    void test_bis_1();
+    void test_bis_2();
+    void test_bis_3();
+    void test_bis_4();
+    void test_bis_5();
 
-    void test_zeroblk_1() throw(libtest::test_exception);
-    void test_zeroblk_2() throw(libtest::test_exception);
-    void test_zeroblk_3() throw(libtest::test_exception);
-    void test_zeroblk_4() throw(libtest::test_exception);
-    void test_zeroblk_5() throw(libtest::test_exception);
-    void test_zeroblk_6() throw(libtest::test_exception);
+    void test_zeroblk_1();
+    void test_zeroblk_2();
+    void test_zeroblk_3();
+    void test_zeroblk_4();
+    void test_zeroblk_5();
+    void test_zeroblk_6();
 
-    void test_contr_1() throw(libtest::test_exception);
-    void test_contr_2() throw(libtest::test_exception);
-    void test_contr_3() throw(libtest::test_exception);
-    void test_contr_4() throw(libtest::test_exception);
-    void test_contr_5() throw(libtest::test_exception);
-    void test_contr_6() throw(libtest::test_exception);
-    void test_contr_7() throw(libtest::test_exception);
-    void test_contr_8() throw(libtest::test_exception);
-    void test_contr_9() throw(libtest::test_exception);
-    void test_contr_10() throw(libtest::test_exception);
-    void test_contr_11() throw(libtest::test_exception);
-    void test_contr_12() throw(libtest::test_exception);
-    void test_contr_13() throw(libtest::test_exception);
-    void test_contr_14(double c) throw(libtest::test_exception);
-    void test_contr_15(double c) throw(libtest::test_exception);
-    void test_contr_16(double c) throw(libtest::test_exception);
-    void test_contr_17(double c) throw(libtest::test_exception);
-    void test_contr_18(double c) throw(libtest::test_exception);
-    void test_contr_19() throw(libtest::test_exception);
-    void test_contr_20a() throw(libtest::test_exception);
-    void test_contr_20b() throw(libtest::test_exception);
-    void test_contr_21() throw(libtest::test_exception);
+    void test_contr_1();
+    void test_contr_2();
+    void test_contr_3();
+    void test_contr_4();
+    void test_contr_5();
+    void test_contr_6();
+    void test_contr_7();
+    void test_contr_8();
+    void test_contr_9();
+    void test_contr_10();
+    void test_contr_11();
+    void test_contr_12();
+    void test_contr_13();
+    void test_contr_14(double c);
+    void test_contr_15(double c);
+    void test_contr_16(double c);
+    void test_contr_17(double c);
+    void test_contr_18(double c);
+    void test_contr_19();
+    void test_contr_20a();
+    void test_contr_20b();
+    void test_contr_21();
     void test_contr_22();
     void test_contr_23();
     void test_contr_24();

--- a/tests/block_tensor/btod_contract2_xm_test.C
+++ b/tests/block_tensor/btod_contract2_xm_test.C
@@ -2190,8 +2190,7 @@ void btod_contract2_xm_test::test_contr_13() {
 }
 
 
-void btod_contract2_xm_test::test_contr_14(double c)
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_14(double c) {
 
     //
     //  c_ijkl = a_ijmn b_klmn
@@ -2265,8 +2264,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_15(double c)
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_15(double c) {
 
     //
     //  c_ijkl = a_ijmn b_klmn
@@ -2345,8 +2343,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_16(double c)
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_16(double c) {
 
     //
     //  c_iabc = a_kcad b_ikbd
@@ -2432,8 +2429,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_17(double c)
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_17(double c) {
 
     //
     //  c_ij = a_jkab b_ikab
@@ -2529,8 +2525,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_18(double c)
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_18(double c) {
 
     //
     //  c_ij = a_jkab b_iakb
@@ -2621,8 +2616,7 @@ throw(libtest::test_exception) {
     }
 }
 
-void btod_contract2_xm_test::test_contr_19()
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_19() {
 
     //
     //  c_ijab = a_ijkl b_klab
@@ -2751,8 +2745,7 @@ throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_20a()
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_20a() {
 
     //
     //  c_iy = a_ix b_xy
@@ -2833,8 +2826,7 @@ throw(libtest::test_exception) {
 
 }
 
-void btod_contract2_xm_test::test_contr_20b()
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_20b() {
 
     //
     //  c_iy = a_ix b_xy
@@ -2938,8 +2930,7 @@ throw(libtest::test_exception) {
 
 }
 
-void btod_contract2_xm_test::test_contr_20c()
-throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_20c() {
 
     //
     //  c_iy = a_ix b_xy

--- a/tests/block_tensor/btod_contract2_xm_test.C
+++ b/tests/block_tensor/btod_contract2_xm_test.C
@@ -20,7 +20,7 @@
 namespace libtensor {
 
 
-void btod_contract2_xm_test::perform() throw(libtest::test_exception) {
+void btod_contract2_xm_test::perform() {
 
     allocator<double>::init();
 
@@ -109,7 +109,7 @@ void btod_contract2_xm_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_bis_1() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_bis_1() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -160,7 +160,7 @@ void btod_contract2_xm_test::test_bis_1() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_bis_2() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_bis_2() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -221,7 +221,7 @@ void btod_contract2_xm_test::test_bis_2() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_bis_3() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_bis_3() {
 
     //
     //  c_ijkl = a_ijkp b_lp
@@ -286,7 +286,7 @@ void btod_contract2_xm_test::test_bis_3() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_bis_4() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_bis_4() {
 
     //
     //  c_ijkl = a_ijpq b_klpq
@@ -331,7 +331,7 @@ void btod_contract2_xm_test::test_bis_4() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_bis_5() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_bis_5() {
 
     //
     //  c_ijk = a_ipqr b_jpqrk
@@ -406,7 +406,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is zero, b is non-zero. Initially, c is zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_xm_test::test_zeroblk_1() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_zeroblk_1() {
 
     static const char *testname = "btod_contract2_xm_test::test_zeroblk_1()";
 
@@ -459,7 +459,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is zero, b is non-zero. Initially, c is non-zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_xm_test::test_zeroblk_2() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_zeroblk_2() {
 
     static const char *testname = "btod_contract2_xm_test::test_zeroblk_2()";
 
@@ -513,7 +513,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is non-zero, b is zero. Initially, c is zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_xm_test::test_zeroblk_3() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_zeroblk_3() {
 
     static const char *testname = "btod_contract2_xm_test::test_zeroblk_3()";
 
@@ -566,7 +566,7 @@ Dimensions: [ijp] = 10. No splitting points. No symmetry.
 The single block of a is non-zero, b is zero. Initially, c is non-zero.
 The result c is expected to have a single zero block.
  **/
-void btod_contract2_xm_test::test_zeroblk_4() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_zeroblk_4() {
 
     static const char *testname = "btod_contract2_xm_test::test_zeroblk_4()";
 
@@ -621,7 +621,7 @@ Only diagonal blocks in a and b are non-zero. Initially, c is zero.
 The result c is expected to have diagonal blocks non-zero and
 off-diagonal blocks zero.
  **/
-void btod_contract2_xm_test::test_zeroblk_5() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_zeroblk_5() {
 
     static const char *testname = "btod_contract2_xm_test::test_zeroblk_5()";
 
@@ -694,7 +694,7 @@ Only diagonal blocks in a and b are non-zero. Initially, c is non-zero.
 The result c is expected to have diagonal blocks non-zero and
 off-diagonal blocks zero.
  **/
-void btod_contract2_xm_test::test_zeroblk_6() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_zeroblk_6() {
 
     static const char *testname = "btod_contract2_xm_test::test_zeroblk_6()";
 
@@ -761,7 +761,7 @@ void btod_contract2_xm_test::test_zeroblk_6() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_mat_1() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_mat_1() {
 
     //
     //  c_ij = a_ip b_jp
@@ -829,7 +829,7 @@ void btod_contract2_xm_test::test_mat_1() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_mat_2() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_mat_2() {
 
     //
     //  c_ij = a_ip b_jp
@@ -913,7 +913,7 @@ void btod_contract2_xm_test::test_mat_2() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_mat_3() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_mat_3() {
 
     //
     //  c_ij = a_ip b_jp
@@ -992,7 +992,7 @@ void btod_contract2_xm_test::test_mat_3() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_1() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_1() {
 
     //
     //  c_ijkl = a_ijpq b_klpq
@@ -1061,7 +1061,7 @@ void btod_contract2_xm_test::test_contr_1() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_1a() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_1a() {
 
     //
     //  c_ijkl = a_ijpq b_klpq
@@ -1168,7 +1168,7 @@ void btod_contract2_xm_test::test_contr_1a() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_1b() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_1b() {
 
     //
     //  c_ijkl = a_ijpq b_klpq
@@ -1279,7 +1279,7 @@ void btod_contract2_xm_test::test_contr_1b() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_2() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_2() {
 
     //
     //  c_ikjl = a_ijpq b_klqp
@@ -1349,7 +1349,7 @@ void btod_contract2_xm_test::test_contr_2() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_3() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_3() {
 
     //
     //  c_ijkl = a_ijpq b_pqkl
@@ -1431,7 +1431,7 @@ void btod_contract2_xm_test::test_contr_3() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_4() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_4() {
 
     //
     //  c_ijkl = a_ijpq b_pqkl
@@ -1524,7 +1524,7 @@ void btod_contract2_xm_test::test_contr_4() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_5() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_5() {
 
     //
     //  c_ijkl = c_ijkl + a_ijpq b_pqkl
@@ -1626,7 +1626,7 @@ void btod_contract2_xm_test::test_contr_5() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_6() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_6() {
 
     //
     //  c_ijkl = c_ijkl + a_ijpq b_pqkl
@@ -1727,7 +1727,7 @@ void btod_contract2_xm_test::test_contr_6() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_7() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_7() {
 
     //
     //  c_ijkl = a_pi b_jklp
@@ -1805,7 +1805,7 @@ void btod_contract2_xm_test::test_contr_7() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_8() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_8() {
 
     //
     //  c_ijkl = a_pi b_jklp
@@ -1873,7 +1873,7 @@ void btod_contract2_xm_test::test_contr_8() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_9() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_9() {
 
     //
     //  c_ijkl = - a_pi b_jklp
@@ -1940,7 +1940,7 @@ void btod_contract2_xm_test::test_contr_9() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_10() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_10() {
 
     //
     //  c_ijkl = - a_pi b_jklp
@@ -1998,7 +1998,7 @@ void btod_contract2_xm_test::test_contr_10() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_11() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_11() {
 
     //
     //  c_ijkl = a_ij b_kl
@@ -2060,7 +2060,7 @@ void btod_contract2_xm_test::test_contr_11() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_12() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_12() {
 
     //
     //  c_ijkl = a_ij b_lk
@@ -2124,7 +2124,7 @@ void btod_contract2_xm_test::test_contr_12() throw(libtest::test_exception) {
 }
 
 
-void btod_contract2_xm_test::test_contr_13() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_13() {
 
     //
     //  c_ij = a_kijl b_kl
@@ -3046,7 +3046,7 @@ throw(libtest::test_exception) {
     No symmetry in A, partition symmetry in B.
     Zero non-diagonal blocks.
  **/
-void btod_contract2_xm_test::test_contr_21() throw(libtest::test_exception) {
+void btod_contract2_xm_test::test_contr_21() {
 
     std::ostringstream ss;
     ss << "btod_contract2_xm_test::test_contr_21()";

--- a/tests/block_tensor/btod_contract2_xm_test.h
+++ b/tests/block_tensor/btod_contract2_xm_test.h
@@ -12,51 +12,51 @@ namespace libtensor {
 **/
 class btod_contract2_xm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_bis_1() throw(libtest::test_exception);
-    void test_bis_2() throw(libtest::test_exception);
-    void test_bis_3() throw(libtest::test_exception);
-    void test_bis_4() throw(libtest::test_exception);
-    void test_bis_5() throw(libtest::test_exception);
+    void test_bis_1();
+    void test_bis_2();
+    void test_bis_3();
+    void test_bis_4();
+    void test_bis_5();
 
-    void test_zeroblk_1() throw(libtest::test_exception);
-    void test_zeroblk_2() throw(libtest::test_exception);
-    void test_zeroblk_3() throw(libtest::test_exception);
-    void test_zeroblk_4() throw(libtest::test_exception);
-    void test_zeroblk_5() throw(libtest::test_exception);
-    void test_zeroblk_6() throw(libtest::test_exception);
+    void test_zeroblk_1();
+    void test_zeroblk_2();
+    void test_zeroblk_3();
+    void test_zeroblk_4();
+    void test_zeroblk_5();
+    void test_zeroblk_6();
 
-    void test_mat_1() throw(libtest::test_exception);
-    void test_mat_2() throw(libtest::test_exception);
-    void test_mat_3() throw(libtest::test_exception);
+    void test_mat_1();
+    void test_mat_2();
+    void test_mat_3();
 
-    void test_contr_1() throw(libtest::test_exception);
-    void test_contr_1a() throw(libtest::test_exception);
-    void test_contr_1b() throw(libtest::test_exception);
-    void test_contr_2() throw(libtest::test_exception);
-    void test_contr_3() throw(libtest::test_exception);
-    void test_contr_4() throw(libtest::test_exception);
-    void test_contr_5() throw(libtest::test_exception);
-    void test_contr_6() throw(libtest::test_exception);
-    void test_contr_7() throw(libtest::test_exception);
-    void test_contr_8() throw(libtest::test_exception);
-    void test_contr_9() throw(libtest::test_exception);
-    void test_contr_10() throw(libtest::test_exception);
-    void test_contr_11() throw(libtest::test_exception);
-    void test_contr_12() throw(libtest::test_exception);
-    void test_contr_13() throw(libtest::test_exception);
-    void test_contr_14(double c) throw(libtest::test_exception);
-    void test_contr_15(double c) throw(libtest::test_exception);
-    void test_contr_16(double c) throw(libtest::test_exception);
-    void test_contr_17(double c) throw(libtest::test_exception);
-    void test_contr_18(double c) throw(libtest::test_exception);
-    void test_contr_19() throw(libtest::test_exception);
-    void test_contr_20a() throw(libtest::test_exception);
-    void test_contr_20b() throw(libtest::test_exception);
-    void test_contr_20c() throw(libtest::test_exception);
-    void test_contr_21() throw(libtest::test_exception);
+    void test_contr_1();
+    void test_contr_1a();
+    void test_contr_1b();
+    void test_contr_2();
+    void test_contr_3();
+    void test_contr_4();
+    void test_contr_5();
+    void test_contr_6();
+    void test_contr_7();
+    void test_contr_8();
+    void test_contr_9();
+    void test_contr_10();
+    void test_contr_11();
+    void test_contr_12();
+    void test_contr_13();
+    void test_contr_14(double c);
+    void test_contr_15(double c);
+    void test_contr_16(double c);
+    void test_contr_17(double c);
+    void test_contr_18(double c);
+    void test_contr_19();
+    void test_contr_20a();
+    void test_contr_20b();
+    void test_contr_20c();
+    void test_contr_21();
     void test_contr_22();
     void test_contr_23();
     void test_contr_24();

--- a/tests/block_tensor/btod_contract3_test.C
+++ b/tests/block_tensor/btod_contract3_test.C
@@ -18,7 +18,7 @@
 namespace libtensor {
 
 
-void btod_contract3_test::perform() throw(libtest::test_exception) {
+void btod_contract3_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/block_tensor/btod_contract3_test.h
+++ b/tests/block_tensor/btod_contract3_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class btod_contract3_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_contr_1();

--- a/tests/block_tensor/btod_copy_test.C
+++ b/tests/block_tensor/btod_copy_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void btod_copy_test::perform() throw(libtest::test_exception) {
+void btod_copy_test::perform() {
 
     allocator<double>::init();
 
@@ -69,7 +69,7 @@ void btod_copy_test::perform() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = a_{ij} \f$, zero tensor
  **/
-void btod_copy_test::test_zero_1() throw(libtest::test_exception) {
+void btod_copy_test::test_zero_1() {
 
     static const char *testname = "btod_copy_test::test_zero_1()";
 
@@ -117,7 +117,7 @@ void btod_copy_test::test_zero_1() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = a_{ij} \f$, zero tensor
  **/
-void btod_copy_test::test_zero_2() throw(libtest::test_exception) {
+void btod_copy_test::test_zero_2() {
 
     static const char *testname = "btod_copy_test::test_zero_2()";
 
@@ -169,7 +169,7 @@ void btod_copy_test::test_zero_2() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = a_{ij} \f$, no symmetry, no blocks
  **/
-void btod_copy_test::test_nosym_1() throw(libtest::test_exception) {
+void btod_copy_test::test_nosym_1() {
 
     static const char *testname = "btod_copy_test::test_nosym_1()";
 
@@ -208,7 +208,7 @@ void btod_copy_test::test_nosym_1() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = 2 a_{ji} \f$, no symmetry, no blocks
  **/
-void btod_copy_test::test_nosym_2() throw(libtest::test_exception) {
+void btod_copy_test::test_nosym_2() {
 
     static const char *testname = "btod_copy_test::test_nosym_2()";
 
@@ -253,7 +253,7 @@ void btod_copy_test::test_nosym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = a_{ij} \f$, no symmetry, 3 blocks along each
         direction
  **/
-void btod_copy_test::test_nosym_3() throw(libtest::test_exception) {
+void btod_copy_test::test_nosym_3() {
 
     static const char *testname = "btod_copy_test::test_nosym_3()";
 
@@ -296,7 +296,7 @@ void btod_copy_test::test_nosym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = 2 a_{ji} \f$, no symmetry, 3 blocks along each
         direction
  **/
-void btod_copy_test::test_nosym_4() throw(libtest::test_exception) {
+void btod_copy_test::test_nosym_4() {
 
     static const char *testname = "btod_copy_test::test_nosym_4()";
 
@@ -345,7 +345,7 @@ void btod_copy_test::test_nosym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = a_{ij} \f$, perm symmetry, 3 blocks along each
         direction
  **/
-void btod_copy_test::test_sym_1() throw(libtest::test_exception) {
+void btod_copy_test::test_sym_1() {
 
     static const char *testname = "btod_copy_test::test_sym_1()";
 
@@ -394,7 +394,7 @@ void btod_copy_test::test_sym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = -2 a_{ji} \f$, perm antisymmetry,
         3 blocks along each direction
  **/
-void btod_copy_test::test_sym_2() throw(libtest::test_exception) {
+void btod_copy_test::test_sym_2() {
 
     static const char *testname = "btod_copy_test::test_sym_2()";
 
@@ -444,7 +444,7 @@ void btod_copy_test::test_sym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijk} = 0.3 a_{kji} \f$, perm symmetry, 3 blocks along each
         direction
  **/
-void btod_copy_test::test_sym_3() throw(libtest::test_exception) {
+void btod_copy_test::test_sym_3() {
 
     static const char *testname = "btod_copy_test::test_sym_3()";
 
@@ -508,7 +508,7 @@ void btod_copy_test::test_sym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = -a_{ijkl} \f$, perm symmetry,
         dim(ij)=10, dim(kl)=12, blocks, non-zero initial B
  **/
-void btod_copy_test::test_sym_4() throw(libtest::test_exception) {
+void btod_copy_test::test_sym_4() {
 
     static const char *testname = "btod_copy_test::test_sym_4()";
 
@@ -574,7 +574,7 @@ void btod_copy_test::test_sym_4() throw(libtest::test_exception) {
 
 /** \test \f$ b_{ij} = b_{ij} + a_{ij} \f$, no symmetry, no blocks
  **/
-void btod_copy_test::test_add_nosym_1() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nosym_1() {
 
     static const char *testname = "btod_copy_test::test_add_nosym_1()";
 
@@ -617,7 +617,7 @@ void btod_copy_test::test_add_nosym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + 2 a_{ji} \f$, no symmetry,
         3 blocks along each direction
  **/
-void btod_copy_test::test_add_nosym_2() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nosym_2() {
 
     static const char *testname = "btod_copy_test::test_add_nosym_2()";
 
@@ -667,7 +667,7 @@ void btod_copy_test::test_add_nosym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 2 a_{ijkl} \f$, no symmetry,
         dim(ij)=10, dim(kl)=12, blocks
  **/
-void btod_copy_test::test_add_nosym_3() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nosym_3() {
 
     static const char *testname = "btod_copy_test::test_add_nosym_3()";
 
@@ -721,7 +721,7 @@ void btod_copy_test::test_add_nosym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + 2 a_{ji} \f$, no symmetry,
         3 blocks along each direction, empty initial B
  **/
-void btod_copy_test::test_add_nosym_4() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nosym_4() {
 
     static const char *testname = "btod_copy_test::test_add_nosym_4()";
 
@@ -770,7 +770,7 @@ void btod_copy_test::test_add_nosym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + a_{ij} \f$, equal perm symmetry,
         3 blocks along each direction
  **/
-void btod_copy_test::test_add_eqsym_1() throw(libtest::test_exception) {
+void btod_copy_test::test_add_eqsym_1() {
 
     static const char *testname = "btod_copy_test::test_add_eqsym_1()";
 
@@ -823,7 +823,7 @@ void btod_copy_test::test_add_eqsym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} - a_{ji} \f$, equal perm antisymmetry,
         3 blocks along each direction
  **/
-void btod_copy_test::test_add_eqsym_2() throw(libtest::test_exception) {
+void btod_copy_test::test_add_eqsym_2() {
 
     static const char *testname = "btod_copy_test::test_add_eqsym_2()";
 
@@ -878,7 +878,7 @@ void btod_copy_test::test_add_eqsym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijk} = b_{ijk} + 0.75 a_{kji} \f$, equal perm symmetry,
         3 blocks along each direction
  **/
-void btod_copy_test::test_add_eqsym_3() throw(libtest::test_exception) {
+void btod_copy_test::test_add_eqsym_3() {
 
     static const char *testname = "btod_copy_test::test_add_eqsym_3()";
 
@@ -947,7 +947,7 @@ void btod_copy_test::test_add_eqsym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 2 a_{ijkl} \f$, equal perm symmetry,
         dim(ij)=10, dim(kl)=12, blocks
  **/
-void btod_copy_test::test_add_eqsym_4() throw(libtest::test_exception) {
+void btod_copy_test::test_add_eqsym_4() {
 
     static const char *testname = "btod_copy_test::test_add_eqsym_4()";
 
@@ -1014,7 +1014,7 @@ void btod_copy_test::test_add_eqsym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ikjl} = b_{ikjl} + 0.5 a_{ijkl} \f$,
         equal perm antisymmetry, dim(ij)=10, dim(kl)=12, blocks
  **/
-void btod_copy_test::test_add_eqsym_5() throw(libtest::test_exception) {
+void btod_copy_test::test_add_eqsym_5() {
 
     static const char *testname = "btod_copy_test::test_add_eqsym_5()";
 
@@ -1083,7 +1083,7 @@ void btod_copy_test::test_add_eqsym_5() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + a_{ij} \f$, unequal perm symmetry,
         Sym(A) > Sym(B) = Sym(B') = Sym(0), blocks
  **/
-void btod_copy_test::test_add_nesym_1() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_1() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_1()";
 
@@ -1135,7 +1135,7 @@ void btod_copy_test::test_add_nesym_1() throw(libtest::test_exception) {
 /** \test \f$ b_{ij} = b_{ij} + a_{ij} \f$, unequal perm symmetry,
         Sym(B) > Sym(A) = Sym(B') = Sym(0), blocks
  **/
-void btod_copy_test::test_add_nesym_2() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_2() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_2()";
 
@@ -1187,7 +1187,7 @@ void btod_copy_test::test_add_nesym_2() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 a_{ijkl} \f$, unequal perm symmetry,
         Sym(A) > Sym(B) = Sym(B') != Sym(0), blocks
  **/
-void btod_copy_test::test_add_nesym_3() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_3() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_3()";
 
@@ -1253,7 +1253,7 @@ void btod_copy_test::test_add_nesym_3() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 a_{ijkl} \f$, unequal perm symmetry,
         Sym(B) > Sym(A) = Sym(B') != Sym(0), blocks
  **/
-void btod_copy_test::test_add_nesym_4() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_4() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_4()";
 
@@ -1319,7 +1319,7 @@ void btod_copy_test::test_add_nesym_4() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 a_{ijkl} \f$, unequal perm symmetry,
         blocks
  **/
-void btod_copy_test::test_add_nesym_5() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_5() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_5()";
 
@@ -1385,7 +1385,7 @@ void btod_copy_test::test_add_nesym_5() throw(libtest::test_exception) {
 /** \test \f$ b_{ijkl} = b_{ijkl} + 1.5 a_{ijkl} \f$, unequal perm symmetry,
         sparse block structure
  **/
-void btod_copy_test::test_add_nesym_5_sp() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_5_sp() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_5_sp()";
 
@@ -1466,7 +1466,7 @@ void btod_copy_test::test_add_nesym_5_sp() throw(libtest::test_exception) {
 /** \test \f$ b_{lkji} = b_{lkji} - 0.1 a_{ijkl} \f$, unequal mixed perm
         symmetry and antisymmetry, blocks
  **/
-void btod_copy_test::test_add_nesym_6() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_6() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_6()";
 
@@ -1538,7 +1538,7 @@ void btod_copy_test::test_add_nesym_6() throw(libtest::test_exception) {
         C[0,1,2,0] = A[0,1,2,0] + B[0,1,0,2],
         A[0,0,1,2] = 0
  **/
-void btod_copy_test::test_add_nesym_7_sp1() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_7_sp1() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_7_sp1()";
 
@@ -1611,7 +1611,7 @@ void btod_copy_test::test_add_nesym_7_sp1() throw(libtest::test_exception) {
         C[0,1,0,2] = B[0,1,0,2],
         C[0,1,2,0] = B[0,1,0,2],
  **/
-void btod_copy_test::test_add_nesym_7_sp2() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_7_sp2() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_7_sp2()";
 
@@ -1684,7 +1684,7 @@ void btod_copy_test::test_add_nesym_7_sp2() throw(libtest::test_exception) {
         C[0,1,2,0] = A[0,1,0,2] + B[0,1,2,0],
         B[0,0,1,2] = 0
  **/
-void btod_copy_test::test_add_nesym_7_sp3() throw(libtest::test_exception) {
+void btod_copy_test::test_add_nesym_7_sp3() {
 
     static const char *testname = "btod_copy_test::test_add_nesym_7_sp3()";
 
@@ -1750,7 +1750,7 @@ void btod_copy_test::test_add_nesym_7_sp3() throw(libtest::test_exception) {
 }
 
 
-void btod_copy_test::test_dir_1() throw(libtest::test_exception) {
+void btod_copy_test::test_dir_1() {
 
 	/*
     static const char *testname = "btod_copy_test::test_dir_1()";
@@ -1790,7 +1790,7 @@ void btod_copy_test::test_dir_1() throw(libtest::test_exception) {
 }
 
 
-void btod_copy_test::test_dir_2() throw(libtest::test_exception) {
+void btod_copy_test::test_dir_2() {
 
 	/*
     static const char *testname = "btod_copy_test::test_dir_2()";
@@ -1840,7 +1840,7 @@ void btod_copy_test::test_dir_2() throw(libtest::test_exception) {
 }
 
 
-void btod_copy_test::test_dir_3() throw(libtest::test_exception) {
+void btod_copy_test::test_dir_3() {
 
     //
     //  b_ijkl = 2.0 * a_ijkl
@@ -1914,7 +1914,7 @@ void btod_copy_test::test_dir_3() throw(libtest::test_exception) {
 }
 
 
-void btod_copy_test::test_dir_4() throw(libtest::test_exception) {
+void btod_copy_test::test_dir_4() {
 
 	/*
     //
@@ -1995,7 +1995,7 @@ void btod_copy_test::test_dir_4() throw(libtest::test_exception) {
 
 /** \test Test for a bug with incorrect combination of transformations
  **/
-void btod_copy_test::test_bug_1() throw(libtest::test_exception) {
+void btod_copy_test::test_bug_1() {
 
     static const char *testname = "btod_copy_test::test_bug_1()";
 

--- a/tests/block_tensor/btod_copy_test.h
+++ b/tests/block_tensor/btod_copy_test.h
@@ -12,45 +12,45 @@ namespace libtensor {
  **/
 class btod_copy_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_zero_1() throw(libtest::test_exception);
-    void test_zero_2() throw(libtest::test_exception);
-    void test_nosym_1() throw(libtest::test_exception);
-    void test_nosym_2() throw(libtest::test_exception);
-    void test_nosym_3() throw(libtest::test_exception);
-    void test_nosym_4() throw(libtest::test_exception);
-    void test_sym_1() throw(libtest::test_exception);
-    void test_sym_2() throw(libtest::test_exception);
-    void test_sym_3() throw(libtest::test_exception);
-    void test_sym_4() throw(libtest::test_exception);
-    void test_add_nosym_1() throw(libtest::test_exception);
-    void test_add_nosym_2() throw(libtest::test_exception);
-    void test_add_nosym_3() throw(libtest::test_exception);
-    void test_add_nosym_4() throw(libtest::test_exception);
-    void test_add_eqsym_1() throw(libtest::test_exception);
-    void test_add_eqsym_2() throw(libtest::test_exception);
-    void test_add_eqsym_3() throw(libtest::test_exception);
-    void test_add_eqsym_4() throw(libtest::test_exception);
-    void test_add_eqsym_5() throw(libtest::test_exception);
-    void test_add_nesym_1() throw(libtest::test_exception);
-    void test_add_nesym_2() throw(libtest::test_exception);
-    void test_add_nesym_3() throw(libtest::test_exception);
-    void test_add_nesym_4() throw(libtest::test_exception);
-    void test_add_nesym_5() throw(libtest::test_exception);
-    void test_add_nesym_5_sp() throw(libtest::test_exception);
-    void test_add_nesym_6() throw(libtest::test_exception);
-    void test_add_nesym_7_sp1() throw(libtest::test_exception);
-    void test_add_nesym_7_sp2() throw(libtest::test_exception);
-    void test_add_nesym_7_sp3() throw(libtest::test_exception);
+    void test_zero_1();
+    void test_zero_2();
+    void test_nosym_1();
+    void test_nosym_2();
+    void test_nosym_3();
+    void test_nosym_4();
+    void test_sym_1();
+    void test_sym_2();
+    void test_sym_3();
+    void test_sym_4();
+    void test_add_nosym_1();
+    void test_add_nosym_2();
+    void test_add_nosym_3();
+    void test_add_nosym_4();
+    void test_add_eqsym_1();
+    void test_add_eqsym_2();
+    void test_add_eqsym_3();
+    void test_add_eqsym_4();
+    void test_add_eqsym_5();
+    void test_add_nesym_1();
+    void test_add_nesym_2();
+    void test_add_nesym_3();
+    void test_add_nesym_4();
+    void test_add_nesym_5();
+    void test_add_nesym_5_sp();
+    void test_add_nesym_6();
+    void test_add_nesym_7_sp1();
+    void test_add_nesym_7_sp2();
+    void test_add_nesym_7_sp3();
 
-    void test_dir_1() throw(libtest::test_exception);
-    void test_dir_2() throw(libtest::test_exception);
-    void test_dir_3() throw(libtest::test_exception);
-    void test_dir_4() throw(libtest::test_exception);
+    void test_dir_1();
+    void test_dir_2();
+    void test_dir_3();
+    void test_dir_4();
 
-    void test_bug_1() throw(libtest::test_exception);
+    void test_bug_1();
 
 };
 

--- a/tests/block_tensor/btod_diag_test.C
+++ b/tests/block_tensor/btod_diag_test.C
@@ -17,7 +17,7 @@
 namespace libtensor {
 
 
-void btod_diag_test::perform() throw(libtest::test_exception) {
+void btod_diag_test::perform() {
 
     allocator<double>::init();
 
@@ -81,7 +81,7 @@ void btod_diag_test::perform() throw(libtest::test_exception) {
 
 /** \test Extract diagonal: \f$ b_i = a_{ii} \f$, zero tensor, one block
  **/
-void btod_diag_test::test_zero_1() throw(libtest::test_exception) {
+void btod_diag_test::test_zero_1() {
 
     static const char *testname = "btod_diag_test::test_zero_1()";
 
@@ -129,7 +129,7 @@ void btod_diag_test::test_zero_1() throw(libtest::test_exception) {
 
 /** \test Extract diagonal: \f$ b_i = a_{ii} \f$, zero tensor, multiple blocks
  **/
-void btod_diag_test::test_zero_2() throw(libtest::test_exception) {
+void btod_diag_test::test_zero_2() {
 
     static const char *testname = "btod_diag_test::test_zero_2()";
 
@@ -184,7 +184,7 @@ void btod_diag_test::test_zero_2() throw(libtest::test_exception) {
 
 /** \test Extract diagonal: \f$ b_ij = a_{ijji} \f$, zero tensor, multiple blocks
  **/
-void btod_diag_test::test_zero_3() throw(libtest::test_exception) {
+void btod_diag_test::test_zero_3() {
 
     static const char *testname = "btod_diag_test::test_zero_3()";
 
@@ -240,7 +240,7 @@ void btod_diag_test::test_zero_3() throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_i = a_{ii} \f$, non-zero tensor,
      single block
  **/
-void btod_diag_test::test_nosym_1(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_nosym_1(bool add) {
 
     static const char *testname = "btod_diag_test::test_nosym_1(bool)";
 
@@ -304,7 +304,7 @@ void btod_diag_test::test_nosym_1(bool add) throw(libtest::test_exception) {
 
 /** \test Extract a single diagonal: \f$ b_{ija} = a_{iajb} \f$
  **/
-void btod_diag_test::test_nosym_2(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_nosym_2(bool add) {
 
     static const char *testname = "btod_diag_test::test_nosym_2(bool)";
 
@@ -381,7 +381,7 @@ void btod_diag_test::test_nosym_2(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_i = a_{ii} \f$, non-zero tensor,
      multiple blocks
  **/
-void btod_diag_test::test_nosym_3(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_nosym_3(bool add) {
 
     static const char *testname = "btod_diag_test::test_nosym_3(bool)";
 
@@ -454,7 +454,7 @@ void btod_diag_test::test_nosym_3(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ija} = a_{iaja} \f$, non-zero tensor,
      multiple blocks with permutation
  **/
-void btod_diag_test::test_nosym_4(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_nosym_4(bool add) {
 
     static const char *testname = "btod_diag_test::test_nosym_4(bool)";
 
@@ -534,7 +534,7 @@ void btod_diag_test::test_nosym_4(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ia} = a_{iiaa} \f$, non-zero tensor,
      multiple blocks
  **/
-void btod_diag_test::test_nosym_5(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_nosym_5(bool add) {
 
     static const char *testname = "btod_diag_test::test_nosym_5(bool)";
 
@@ -610,7 +610,7 @@ void btod_diag_test::test_nosym_5(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ija} = a_{iaija} \f$, non-zero tensor,
      multiple blocks with permutation
  **/
-void btod_diag_test::test_nosym_6(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_nosym_6(bool add) {
 
     static const char *testname = "btod_diag_test::test_nosym_6(bool)";
 
@@ -689,7 +689,7 @@ void btod_diag_test::test_nosym_6(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_i = a_{ii} \f$, permutational symmetry,
      multiple blocks
  **/
-void btod_diag_test::test_sym_1(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_1(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_1(bool)";
 
@@ -768,7 +768,7 @@ void btod_diag_test::test_sym_1(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ia} = a_{iia} \f$, permutational symmetry,
      multiple blocks
  **/
-void btod_diag_test::test_sym_2(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_2(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_2(bool)";
 
@@ -856,7 +856,7 @@ void btod_diag_test::test_sym_2(bool add) throw(libtest::test_exception) {
 
     TODO: Remove this test!!!
  **/
-void btod_diag_test::test_sym_3(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_3(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_3(bool)";
 
@@ -936,7 +936,7 @@ void btod_diag_test::test_sym_3(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ija} = a_{iaja} \f$, permutational anti-symmetry,
      multiple blocks
  **/
-void btod_diag_test::test_sym_4(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_4(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_4(bool)";
 
@@ -1023,7 +1023,7 @@ void btod_diag_test::test_sym_4(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{iaj} = a_{iaja} \f$,
         permutational symmetry, multiple blocks
  **/
-void btod_diag_test::test_sym_5(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_5(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_5(bool)";
 
@@ -1112,7 +1112,7 @@ void btod_diag_test::test_sym_5(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ijk} = a_{ikjk} \f$,
         permutational anti-symmetry, multiple blocks
  **/
-void btod_diag_test::test_sym_6(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_6(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_6(bool)";
 
@@ -1188,7 +1188,7 @@ void btod_diag_test::test_sym_6(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_i = a_{ii} \f$, non-zero tensor,
         multiple blocks, label symmetry
  **/
-void btod_diag_test::test_sym_7(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_7(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_7(bool)";
 
@@ -1296,7 +1296,7 @@ void btod_diag_test::test_sym_7(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_ijk = a_{ijkj} \f$, non-zero tensor,
         multiple blocks, perm and partition symmetry
  **/
-void btod_diag_test::test_sym_8(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_8(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_8(bool)";
 
@@ -1422,7 +1422,7 @@ void btod_diag_test::test_sym_8(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ij} = a_{ijij} \f$,
         permutational anti-symmetry, multiple blocks
  **/
-void btod_diag_test::test_sym_9(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_9(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_9(bool)";
 
@@ -1508,7 +1508,7 @@ void btod_diag_test::test_sym_9(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ia} = a_{aaii} \f$, non-zero tensor,
         multiple blocks, label symmetry
  **/
-void btod_diag_test::test_sym_10(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_10(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_10(bool)";
 
@@ -1653,7 +1653,7 @@ void btod_diag_test::test_sym_10(bool add) throw(libtest::test_exception) {
 /** \test Extract diagonal: \f$ b_{ij} = a_{ijji} \f$, non-zero tensor,
         multiple blocks, perm and partition symmetry
  **/
-void btod_diag_test::test_sym_11(bool add) throw(libtest::test_exception) {
+void btod_diag_test::test_sym_11(bool add) {
 
     static const char *testname = "btod_diag_test::test_sym_11(bool)";
 

--- a/tests/block_tensor/btod_diag_test.h
+++ b/tests/block_tensor/btod_diag_test.h
@@ -11,29 +11,29 @@ namespace libtensor {
 **/
 class btod_diag_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_zero_1() throw(libtest::test_exception);
-    void test_zero_2() throw(libtest::test_exception);
-    void test_zero_3() throw(libtest::test_exception);
-    void test_nosym_1(bool add) throw(libtest::test_exception);
-    void test_nosym_2(bool add) throw(libtest::test_exception);
-    void test_nosym_3(bool add) throw(libtest::test_exception);
-    void test_nosym_4(bool add) throw(libtest::test_exception);
-    void test_nosym_5(bool add) throw(libtest::test_exception);
-    void test_nosym_6(bool add) throw(libtest::test_exception);
-    void test_sym_1(bool add) throw(libtest::test_exception);
-    void test_sym_2(bool add) throw(libtest::test_exception);
-    void test_sym_3(bool add) throw(libtest::test_exception);
-    void test_sym_4(bool add) throw(libtest::test_exception);
-    void test_sym_5(bool add) throw(libtest::test_exception);
-    void test_sym_6(bool add) throw(libtest::test_exception);
-    void test_sym_7(bool add) throw(libtest::test_exception);
-    void test_sym_8(bool add) throw(libtest::test_exception);
-    void test_sym_9(bool add) throw(libtest::test_exception);
-    void test_sym_10(bool add) throw(libtest::test_exception);
-    void test_sym_11(bool add) throw(libtest::test_exception);
+    void test_zero_1();
+    void test_zero_2();
+    void test_zero_3();
+    void test_nosym_1(bool add);
+    void test_nosym_2(bool add);
+    void test_nosym_3(bool add);
+    void test_nosym_4(bool add);
+    void test_nosym_5(bool add);
+    void test_nosym_6(bool add);
+    void test_sym_1(bool add);
+    void test_sym_2(bool add);
+    void test_sym_3(bool add);
+    void test_sym_4(bool add);
+    void test_sym_5(bool add);
+    void test_sym_6(bool add);
+    void test_sym_7(bool add);
+    void test_sym_8(bool add);
+    void test_sym_9(bool add);
+    void test_sym_10(bool add);
+    void test_sym_11(bool add);
 
 };
 

--- a/tests/block_tensor/btod_diagonalize_test.C
+++ b/tests/block_tensor/btod_diagonalize_test.C
@@ -11,7 +11,7 @@
 namespace libtensor {
 
 
-void btod_diagonalize_test::perform() throw(libtest::test_exception) {
+void btod_diagonalize_test::perform() {
 
     allocator<double>::init();
 
@@ -34,7 +34,7 @@ void btod_diagonalize_test::perform() throw(libtest::test_exception) {
 
 /** \diagonalize matrix 3x3
  **/
-void btod_diagonalize_test::test_1() throw(libtest::test_exception) {
+void btod_diagonalize_test::test_1() {
 
     static const char *testname = "btod_diagonalize_test::test_1()";
 
@@ -108,7 +108,7 @@ void btod_diagonalize_test::test_1() throw(libtest::test_exception) {
 
 /** \diagonalize matrix 4x4 with fragmentation
  **/
-void btod_diagonalize_test::test_2() throw(libtest::test_exception) {
+void btod_diagonalize_test::test_2() {
 
     static const char *testname = "btod_diagonalize_test::test_2()";
 
@@ -188,7 +188,7 @@ void btod_diagonalize_test::test_2() throw(libtest::test_exception) {
 
 /** \diagonalize matrix 3x3
  **/
-void btod_diagonalize_test::test_3() throw(libtest::test_exception) {
+void btod_diagonalize_test::test_3() {
 
     static const char *testname = "btod_diagonalize_test::test_3()";
 
@@ -264,7 +264,7 @@ void btod_diagonalize_test::test_3() throw(libtest::test_exception) {
 
 /** \diagonalize matrix 4x4 with fragmentation
  **/
-void btod_diagonalize_test::test_4() throw(libtest::test_exception) {
+void btod_diagonalize_test::test_4() {
 
     static const char *testname = "btod_diagonalize_test::test_4()";
 
@@ -342,7 +342,7 @@ void btod_diagonalize_test::test_4() throw(libtest::test_exception) {
 
 /** \diagonalize matrix 5x5 with fragmentation
  **/
-void btod_diagonalize_test::test_5() throw(libtest::test_exception) {
+void btod_diagonalize_test::test_5() {
 
     static const char *testname = "btod_diagonalize_test::test_5()";
 

--- a/tests/block_tensor/btod_diagonalize_test.h
+++ b/tests/block_tensor/btod_diagonalize_test.h
@@ -11,14 +11,14 @@ namespace libtensor {
 **/
 class btod_diagonalize_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_dirsum_test.C
+++ b/tests/block_tensor/btod_dirsum_test.C
@@ -21,7 +21,7 @@
 namespace libtensor {
 
 
-void btod_dirsum_test::perform() throw(libtest::test_exception) {
+void btod_dirsum_test::perform() {
 
     allocator<double>::init();
 
@@ -103,7 +103,7 @@ void btod_dirsum_test::perform() throw(libtest::test_exception) {
 }
 
 void btod_dirsum_test::test_ij_i_j_1(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     //  c_{ij} = a_i + b_j
 
@@ -170,7 +170,7 @@ void btod_dirsum_test::test_ij_i_j_1(bool rnd, double d)
 }
 
 void btod_dirsum_test::test_ij_i_j_2(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     //  c_{ij} = a_i + a_j
 
@@ -258,7 +258,7 @@ void btod_dirsum_test::test_ij_i_j_2(bool rnd, double d)
 }
 
 void btod_dirsum_test::test_ij_i_j_3(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     //  c_{ij} = a_i - a_j
 
@@ -346,7 +346,7 @@ void btod_dirsum_test::test_ij_i_j_3(bool rnd, double d)
 }
 
 void btod_dirsum_test::test_ijk_ij_k_1(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     // c_{ijk} = a_{ij} + b_k
 
@@ -421,7 +421,7 @@ void btod_dirsum_test::test_ijk_ij_k_1(bool rnd, double d)
 }
 
 void btod_dirsum_test::test_ikjl_ij_kl_1(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     //  c_{ikjl} = a_{ij} + b_{kl}
 
@@ -497,7 +497,7 @@ void btod_dirsum_test::test_ikjl_ij_kl_1(bool rnd, double d)
 }
 
 void btod_dirsum_test::test_ikjl_ij_kl_2(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     //  c_{ikjl} = a_{ij} + b_{kl}
     // with splits
@@ -600,7 +600,7 @@ void btod_dirsum_test::test_ikjl_ij_kl_2(bool rnd, double d)
 }
 
 void btod_dirsum_test::test_ikjl_ij_kl_3a(bool s1, bool s2,
-        bool rnd, double d) throw(libtest::test_exception) {
+        bool rnd, double d) {
 
     //  c_{ikjl} = a_{ij} + b_{kl}
     // with splits and se_perm i<->j, k<->l
@@ -727,7 +727,7 @@ void btod_dirsum_test::test_ikjl_ij_kl_3a(bool s1, bool s2,
 }
 
 void btod_dirsum_test::test_ikjl_ij_kl_3b(bool rnd,
-        double d) throw(libtest::test_exception) {
+        double d) {
 
     //  c_{ikjl} = a_{ij} + b_{kl}
     // with splits and se_part
@@ -874,7 +874,7 @@ void btod_dirsum_test::test_ikjl_ij_kl_3b(bool rnd,
 }
 
 void btod_dirsum_test::test_ikjl_ij_kl_3c(
-        bool rnd, double d) throw(libtest::test_exception) {
+        bool rnd, double d) {
 
     //  c_{ikjl} = a_{ij} + b_{kl}
     // with splits and se_label
@@ -1032,7 +1032,7 @@ void btod_dirsum_test::test_ikjl_ij_kl_3c(
 }
 
 void btod_dirsum_test::test_iklj_ij_kl_1(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     //  c_{iklj} = a_{ij} + a_{kl}
     // with splits and symmetry
@@ -1166,7 +1166,7 @@ void btod_dirsum_test::test_iklj_ij_kl_1(bool rnd, double d)
 }
 
 void btod_dirsum_test::test_ikmjln_ij_kl_mn(bool rnd, double d)
-    throw(libtest::test_exception) {
+    {
 
     // b_{ijkl} = a_{ij} + a_{kl}
     // c_{ikmjln} = b_{ijkl} + a_{mn}

--- a/tests/block_tensor/btod_dirsum_test.h
+++ b/tests/block_tensor/btod_dirsum_test.h
@@ -11,54 +11,54 @@ namespace libtensor {
 **/
 class btod_dirsum_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     // c_{ij} = a_i + b_j
     void test_ij_i_j_1(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ij} = a_i + a_j (with more than 1 block, checking for symmetry)
     void test_ij_i_j_2(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ij} = a_i - a_j (with more than 1 block, checking for symmetry)
     void test_ij_i_j_3(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ijk} = a_{ij} + b_k
     void test_ijk_ij_k_1(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ikjl} = a_{ij} + b_{kl}
     void test_ikjl_ij_kl_1(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ikjl} = a_{ij} + b_{kl} (with more than 1 block)
     void test_ikjl_ij_kl_2(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ikjl} = a_{ij} + b_{kl} (with more than 1 block and se_perm)
     void test_ikjl_ij_kl_3a(bool s1, bool s2, bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ikjl} = a_{ij} + b_{kl} (with more than 1 block and se_part)
     void test_ikjl_ij_kl_3b(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{ikjl} = a_{ij} + b_{kl} (with more than 1 block and se_label)
     void test_ikjl_ij_kl_3c(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // c_{iklj} = a_{ij} + a_{kl} (with more than 1 block and symmetry elements)
     void test_iklj_ij_kl_1(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
     // b_{ijkl} = a_{ij} + a_{kl}
     // c_{ikmjln} = b_{ijkl} + a_{mn}
     // (with more than 1 block and symmetry elements)
     void test_ikmjln_ij_kl_mn(bool rnd, double d = 0.0)
-        throw(libtest::test_exception);
+       ;
 
 };
 

--- a/tests/block_tensor/btod_dotprod_test.C
+++ b/tests/block_tensor/btod_dotprod_test.C
@@ -18,7 +18,7 @@
 namespace libtensor {
 
 
-void btod_dotprod_test::perform() throw(libtest::test_exception) {
+void btod_dotprod_test::perform() {
 
     allocator<double>::init();
     try {
@@ -50,7 +50,7 @@ void btod_dotprod_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_1() throw(libtest::test_exception) {
+void btod_dotprod_test::test_1() {
 
     //
     //  Single block, both arguments are non-zero
@@ -99,7 +99,7 @@ void btod_dotprod_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_2() throw(libtest::test_exception) {
+void btod_dotprod_test::test_2() {
 
     //
     //  Single block, one of the arguments is zero
@@ -141,7 +141,7 @@ void btod_dotprod_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_3() throw(libtest::test_exception) {
+void btod_dotprod_test::test_3() {
 
     //
     //  Two blocks in each dimension, both arguments are non-zero
@@ -194,7 +194,7 @@ void btod_dotprod_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_4() throw(libtest::test_exception) {
+void btod_dotprod_test::test_4() {
 
     //
     //  Two blocks in each dimension, off-diagonal blocks of one of
@@ -251,7 +251,7 @@ void btod_dotprod_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_5() throw(libtest::test_exception) {
+void btod_dotprod_test::test_5() {
 
     //
     //  Two blocks in each dimension, multiple non-zero arguments
@@ -324,7 +324,7 @@ void btod_dotprod_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_6() throw(libtest::test_exception) {
+void btod_dotprod_test::test_6() {
 
     //
     //  Two blocks in each dimension, multiple non-zero arguments
@@ -405,7 +405,7 @@ void btod_dotprod_test::test_6() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_7() throw(libtest::test_exception) {
+void btod_dotprod_test::test_7() {
 
     //
     //  Three blocks in each dimension, both arguments are non-zero,
@@ -472,7 +472,7 @@ void btod_dotprod_test::test_7() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_8() throw(libtest::test_exception) {
+void btod_dotprod_test::test_8() {
 
     //
     //  Three blocks in each dimension, multiple non-zero arguments,
@@ -589,7 +589,7 @@ void btod_dotprod_test::test_8() throw(libtest::test_exception) {
     }
 }
 
-void btod_dotprod_test::test_9() throw(libtest::test_exception) {
+void btod_dotprod_test::test_9() {
 
     //
     //  Four blocks in each dimension, multiple non-zero arguments,
@@ -657,7 +657,7 @@ void btod_dotprod_test::test_9() throw(libtest::test_exception) {
     }
 }
 
-void btod_dotprod_test::test_10a() throw(libtest::test_exception) {
+void btod_dotprod_test::test_10a() {
 
     //
     //  Four blocks in each dimension, multiple non-zero arguments,
@@ -748,7 +748,7 @@ void btod_dotprod_test::test_10a() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_10b() throw(libtest::test_exception) {
+void btod_dotprod_test::test_10b() {
 
     //
     //  Four blocks in each dimension, multiple non-zero arguments,
@@ -852,7 +852,7 @@ void btod_dotprod_test::test_10b() throw(libtest::test_exception) {
 
 
 void btod_dotprod_test::test_10c(
-        bool both) throw(libtest::test_exception) {
+        bool both) {
 
     //
     //  Two blocks in each dimension, multiple non-zero arguments,
@@ -930,7 +930,7 @@ void btod_dotprod_test::test_10c(
 }
 
 
-void btod_dotprod_test::test_11() throw(libtest::test_exception) {
+void btod_dotprod_test::test_11() {
 
     //
     //  Two blocks in each dimension, subtle splitting differences
@@ -986,7 +986,7 @@ void btod_dotprod_test::test_11() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_12() throw(libtest::test_exception) {
+void btod_dotprod_test::test_12() {
 
     //
     //  Two blocks in each dimension, subtle splitting differences
@@ -1044,7 +1044,7 @@ void btod_dotprod_test::test_12() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_13a() throw(libtest::test_exception) {
+void btod_dotprod_test::test_13a() {
 
     //  3-dim tensor, four blocks in each dimension,
     //  permutational anti-symmetry
@@ -1116,7 +1116,7 @@ void btod_dotprod_test::test_13a() throw(libtest::test_exception) {
 }
 
 
-void btod_dotprod_test::test_13b() throw(libtest::test_exception) {
+void btod_dotprod_test::test_13b() {
 
     //  3-dim tensor, four blocks in each dimension,
     //  permutational anti-symmetry

--- a/tests/block_tensor/btod_dotprod_test.h
+++ b/tests/block_tensor/btod_dotprod_test.h
@@ -11,25 +11,25 @@ namespace libtensor {
 **/
 class btod_dotprod_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
-    void test_10a() throw(libtest::test_exception);
-    void test_10b() throw(libtest::test_exception);
-    void test_10c(bool both) throw(libtest::test_exception);
-    void test_11() throw(libtest::test_exception);
-    void test_12() throw(libtest::test_exception);
-    void test_13a() throw(libtest::test_exception);
-    void test_13b() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
+    void test_9();
+    void test_10a();
+    void test_10b();
+    void test_10c(bool both);
+    void test_11();
+    void test_12();
+    void test_13a();
+    void test_13b();
 
 };
 

--- a/tests/block_tensor/btod_ewmult2_test.C
+++ b/tests/block_tensor/btod_ewmult2_test.C
@@ -18,7 +18,7 @@
 namespace libtensor {
 
 
-void btod_ewmult2_test::perform() throw(libtest::test_exception) {
+void btod_ewmult2_test::perform() {
 
     allocator<double>::init();
 
@@ -49,7 +49,7 @@ void btod_ewmult2_test::perform() throw(libtest::test_exception) {
 
 /** \test $c_{i} = a_{i} b_{i}$
  **/
-void btod_ewmult2_test::test_1(bool doadd) throw(libtest::test_exception) {
+void btod_ewmult2_test::test_1(bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_ewmult2_test::test_1(" << doadd << ")";
@@ -125,7 +125,7 @@ void btod_ewmult2_test::test_1(bool doadd) throw(libtest::test_exception) {
 
 /** \test $c_{ij} = a_{ij} b_{ij}$
  **/
-void btod_ewmult2_test::test_2(bool doadd) throw(libtest::test_exception) {
+void btod_ewmult2_test::test_2(bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_ewmult2_test::test_2(" << doadd << ")";
@@ -209,7 +209,7 @@ void btod_ewmult2_test::test_2(bool doadd) throw(libtest::test_exception) {
 
 /** \test $c_{ij} = a_{ij} b_{ji}$
  **/
-void btod_ewmult2_test::test_3(bool doadd) throw(libtest::test_exception) {
+void btod_ewmult2_test::test_3(bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_ewmult2_test::test_3(" << doadd << ")";
@@ -293,7 +293,7 @@ void btod_ewmult2_test::test_3(bool doadd) throw(libtest::test_exception) {
 
 /** \test $c_{ijkl} = a_{kj} b_{ikl}$
  **/
-void btod_ewmult2_test::test_4(bool doadd) throw(libtest::test_exception) {
+void btod_ewmult2_test::test_4(bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_ewmult2_test::test_4(" << doadd << ")";
@@ -385,7 +385,7 @@ void btod_ewmult2_test::test_4(bool doadd) throw(libtest::test_exception) {
 
 /** \test $c_{ijkl} = a_{ljk} b_{jil}$
  **/
-void btod_ewmult2_test::test_5(bool doadd) throw(libtest::test_exception) {
+void btod_ewmult2_test::test_5(bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_ewmult2_test::test_5(" << doadd << ")";
@@ -481,7 +481,7 @@ void btod_ewmult2_test::test_5(bool doadd) throw(libtest::test_exception) {
 
 /** \test $c_{ijkl} = a_{ikl} b_{jkl}$, perm symmetry
  **/
-void btod_ewmult2_test::test_6(bool doadd) throw(libtest::test_exception) {
+void btod_ewmult2_test::test_6(bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_ewmult2_test::test_6(" << doadd << ")";
@@ -606,7 +606,7 @@ void btod_ewmult2_test::test_6(bool doadd) throw(libtest::test_exception) {
 
 /** \test $c_{ijk} = a_{ij} b_{ik}$, label symmetry
  **/
-void btod_ewmult2_test::test_7() throw(libtest::test_exception) {
+void btod_ewmult2_test::test_7() {
 
     std::ostringstream tnss;
     tnss << "btod_ewmult2_test::test_7()";

--- a/tests/block_tensor/btod_ewmult2_test.h
+++ b/tests/block_tensor/btod_ewmult2_test.h
@@ -12,16 +12,16 @@ namespace libtensor {
  **/
 class btod_ewmult2_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(bool doadd) throw(libtest::test_exception);
-    void test_2(bool doadd) throw(libtest::test_exception);
-    void test_3(bool doadd) throw(libtest::test_exception);
-    void test_4(bool doadd) throw(libtest::test_exception);
-    void test_5(bool doadd) throw(libtest::test_exception);
-    void test_6(bool doadd) throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
+    void test_1(bool doadd);
+    void test_2(bool doadd);
+    void test_3(bool doadd);
+    void test_4(bool doadd);
+    void test_5(bool doadd);
+    void test_6(bool doadd);
+    void test_7();
 
 };
 

--- a/tests/block_tensor/btod_extract_test.C
+++ b/tests/block_tensor/btod_extract_test.C
@@ -12,7 +12,7 @@
 namespace libtensor {
 
 
-void btod_extract_test::perform() throw(libtest::test_exception) {
+void btod_extract_test::perform() {
 
     allocator<double>::init();
 
@@ -45,7 +45,7 @@ void btod_extract_test::perform() throw(libtest::test_exception) {
 
 /** \test Extract a single column b_j = a_ij where i is constant
  **/
-void btod_extract_test::test_1() throw(libtest::test_exception) {
+void btod_extract_test::test_1() {
 
     static const char *testname = "btod_extract_test::test_1()";
 
@@ -100,7 +100,7 @@ void btod_extract_test::test_1() throw(libtest::test_exception) {
 
 /** \test Extract a matrix from the 3rd order tensor \f$ b_{ia} = a_{iba} \f$
  **/
-void btod_extract_test::test_2() throw(libtest::test_exception) {
+void btod_extract_test::test_2() {
 
     static const char *testname = "btod_extract_test::test_2()";
 
@@ -157,7 +157,7 @@ void btod_extract_test::test_2() throw(libtest::test_exception) {
  * \f$ b_{jkm} = a_{ijklm} \f$
  **/
 
-void btod_extract_test::test_3() throw(libtest::test_exception) {
+void btod_extract_test::test_3() {
 
     static const char *testname = "btod_extract_test::test_3()";
 
@@ -213,7 +213,7 @@ void btod_extract_test::test_3() throw(libtest::test_exception) {
 /** \test Extract a matrix from the 5rd order tensor
  * \f$ b_{jl} = a_{ijklm} \f$
  **/
-void btod_extract_test::test_4() throw(libtest::test_exception) {
+void btod_extract_test::test_4() {
 
     static const char *testname = "btod_extract_test::test_4()";
 
@@ -271,7 +271,7 @@ void btod_extract_test::test_4() throw(libtest::test_exception) {
 /** \test Extract a vector from the matrix with splitting
  * \f$ b_{j} = a_{ij} \f$
  **/
-void btod_extract_test::test_5() throw(libtest::test_exception) {
+void btod_extract_test::test_5() {
 
     static const char *testname = "btod_extract_test::test_5()";
 
@@ -334,7 +334,7 @@ void btod_extract_test::test_5() throw(libtest::test_exception) {
 /** \test Extract a matrix from the 3rd order tensor with splitting
  * \f$ b_{ik} = a_{ijk} \f$
  **/
-void btod_extract_test::test_6() throw(libtest::test_exception) {
+void btod_extract_test::test_6() {
 
     static const char *testname = "btod_extract_test::test_6()";
 
@@ -405,7 +405,7 @@ void btod_extract_test::test_6() throw(libtest::test_exception) {
  **/
 
 
-void btod_extract_test::test_7() throw(libtest::test_exception) {
+void btod_extract_test::test_7() {
 
     static const char *testname = "btod_extract_test::test_7()";
 
@@ -476,7 +476,7 @@ void btod_extract_test::test_7() throw(libtest::test_exception) {
 /** \test Extract a matrix from the 4rd order tensor with splitting
  * \f$ b_{il} = a_{ijkl} \f$
  **/
-void btod_extract_test::test_8() throw(libtest::test_exception) {
+void btod_extract_test::test_8() {
 
     static const char *testname = "btod_extract_test::test_8()";
 
@@ -548,7 +548,7 @@ void btod_extract_test::test_8() throw(libtest::test_exception) {
 /** \test Extract a matrix from the 3rd order tensor with splitting and
  * permutation \f$ b_{ki} = a_{ijk} \f$
  **/
-void btod_extract_test::test_9() throw(libtest::test_exception) {
+void btod_extract_test::test_9() {
 
     static const char *testname = "btod_extract_test::test_9()";
 
@@ -608,7 +608,7 @@ void btod_extract_test::test_9() throw(libtest::test_exception) {
 /** \test Extract a matrix from the 4rd order tensor with splitting and symmetry
         \f$ b_{il} = a_{ijkl} \f$
  **/
-void btod_extract_test::test_10() throw(libtest::test_exception) {
+void btod_extract_test::test_10() {
 
     static const char *testname = "btod_extract_test::test_10()";
 
@@ -700,7 +700,7 @@ void btod_extract_test::test_10() throw(libtest::test_exception) {
 /** \test Extract a matrix from the 3rd order tensor with splitting,
  * permutation, and symmetry \f$ b_{ki} = a_{ijk} \f$
  **/
-void btod_extract_test::test_11() throw(libtest::test_exception) {
+void btod_extract_test::test_11() {
 
     static const char *testname = "btod_extract_test::test_11()";
 
@@ -771,7 +771,7 @@ void btod_extract_test::test_11() throw(libtest::test_exception) {
         and perm symmetry
           \f$ b_{jl} = a_{ijkl} \qquad a_{ijkl} = a_{klij} \f$
  **/
-void btod_extract_test::test_12a() throw(libtest::test_exception) {
+void btod_extract_test::test_12a() {
 
     static const char *testname = "btod_extract_test::test_12a()";
 
@@ -858,7 +858,7 @@ void btod_extract_test::test_12a() throw(libtest::test_exception) {
         and perm symmetry (additive, b has perm symmetry)
           \f$ b_{jl} = b_{jl} + a_{ijkl} \qquad a_{ijkl} = a_{klij} \f$
  **/
-void btod_extract_test::test_12b() throw(libtest::test_exception) {
+void btod_extract_test::test_12b() {
 
     static const char *testname = "btod_extract_test::test_12b()";
 
@@ -951,7 +951,7 @@ void btod_extract_test::test_12b() throw(libtest::test_exception) {
         and perm symmetry (additive, b has no symmetry)
           \f$ b_{jl} = b_{jl} + a_{ijkl} \qquad a_{ijkl} = a_{klij} \f$
  **/
-void btod_extract_test::test_12c() throw(libtest::test_exception) {
+void btod_extract_test::test_12c() {
 
     static const char *testname = "btod_extract_test::test_12c()";
 
@@ -1040,7 +1040,7 @@ void btod_extract_test::test_12c() throw(libtest::test_exception) {
         and perm symmetry
           \f$ b_{ak} = a_{ijka} \qquad a_{ijka} = -a_{jika} \f$
  **/
-void btod_extract_test::test_13a() throw(libtest::test_exception) {
+void btod_extract_test::test_13a() {
 
     static const char *testname = "btod_extract_test::test_13a()";
 

--- a/tests/block_tensor/btod_extract_test.h
+++ b/tests/block_tensor/btod_extract_test.h
@@ -11,24 +11,24 @@ namespace libtensor {
 **/
 class btod_extract_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
-    void test_10() throw(libtest::test_exception);
-    void test_11() throw(libtest::test_exception);
-    void test_12a() throw(libtest::test_exception);
-    void test_12b() throw(libtest::test_exception);
-    void test_12c() throw(libtest::test_exception);
-    void test_13a() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
+    void test_9();
+    void test_10();
+    void test_11();
+    void test_12a();
+    void test_12b();
+    void test_12c();
+    void test_13a();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_import_raw_stream_test.C
+++ b/tests/block_tensor/btod_import_raw_stream_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void btod_import_raw_stream_test::perform() throw(libtest::test_exception) {
+void btod_import_raw_stream_test::perform() {
 
     libtensor::index<2> i2a, i2b;
     i2b[0] = 9; i2b[1] = 19;
@@ -48,7 +48,7 @@ void btod_import_raw_stream_test::perform() throw(libtest::test_exception) {
 
 template<size_t N>
 void btod_import_raw_stream_test::test_1(const block_index_space<N> &bis)
-    throw(libtest::test_exception) {
+    {
 
     std::ostringstream tnss;
     tnss << "btod_import_raw_stream_test::test_1(" << bis << ")";
@@ -96,7 +96,7 @@ void btod_import_raw_stream_test::test_1(const block_index_space<N> &bis)
 
 template<size_t N>
 void btod_import_raw_stream_test::test_2(const block_index_space<N> &bis)
-    throw(libtest::test_exception) {
+    {
 
     std::ostringstream tnss;
     tnss << "btod_import_raw_stream_test::test_2(" << bis << ")";

--- a/tests/block_tensor/btod_import_raw_test.C
+++ b/tests/block_tensor/btod_import_raw_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void btod_import_raw_test::perform() throw(libtest::test_exception) {
+void btod_import_raw_test::perform() {
 
     libtensor::index<2> i2a, i2b;
     i2b[0] = 9; i2b[1] = 19;
@@ -48,7 +48,7 @@ void btod_import_raw_test::perform() throw(libtest::test_exception) {
 
 template<size_t N>
 void btod_import_raw_test::test_1(const block_index_space<N> &bis)
-    throw(libtest::test_exception) {
+    {
 
     std::ostringstream tnss;
     tnss << "btod_import_raw_test::test_1(" << bis << ")";
@@ -94,7 +94,7 @@ void btod_import_raw_test::test_1(const block_index_space<N> &bis)
 
 template<size_t N>
 void btod_import_raw_test::test_2(const block_index_space<N> &bis)
-    throw(libtest::test_exception) {
+    {
 
     std::ostringstream tnss;
     tnss << "btod_import_raw_test::test_2(" << bis << ")";

--- a/tests/block_tensor/btod_import_raw_test.h
+++ b/tests/block_tensor/btod_import_raw_test.h
@@ -12,16 +12,16 @@ namespace libtensor {
  **/
 class btod_import_raw_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     template<size_t N>
     void test_1(const block_index_space<N> &bis)
-    throw(libtest::test_exception);
+   ;
 
     template<size_t N>
     void test_2(const block_index_space<N> &bis)
-        throw(libtest::test_exception);
+       ;
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_mult1_test.C
+++ b/tests/block_tensor/btod_mult1_test.C
@@ -16,7 +16,7 @@
 namespace libtensor {
 
 
-void btod_mult1_test::perform() throw(libtest::test_exception) {
+void btod_mult1_test::perform() {
 
     allocator<double>::init();
 
@@ -45,7 +45,7 @@ void btod_mult1_test::perform() throw(libtest::test_exception) {
         and no zero blocks.
  **/
 void btod_mult1_test::test_1(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     std::ostringstream oss;
     oss << "btod_mult1_test::test_1("
@@ -102,7 +102,7 @@ void btod_mult1_test::test_1(
         with no symmetry and no zero blocks, second tensor permuted.
  **/
 void btod_mult1_test::test_2(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     std::ostringstream oss;
     oss << "btod_mult1_test::test_2("
@@ -161,7 +161,7 @@ void btod_mult1_test::test_2(
         and zero blocks (scaled)
  **/
 void btod_mult1_test::test_3(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     std::ostringstream oss;
     oss << "btod_mult1_test::test_3("
@@ -236,7 +236,7 @@ void btod_mult1_test::test_3(
         with symmetry and zero blocks, second tensor permuted
  **/
 void btod_mult1_test::test_4(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     std::ostringstream oss;
     oss << "btod_mult1_test::test_4("
@@ -314,7 +314,7 @@ void btod_mult1_test::test_4(
         symmetry no zero blocks.
  **/
 void btod_mult1_test::test_5(bool recip, bool doadd)
-    throw(libtest::test_exception) {
+    {
 
     std::ostringstream oss;
     oss << "btod_mult1_test::test_5("

--- a/tests/block_tensor/btod_mult1_test.h
+++ b/tests/block_tensor/btod_mult1_test.h
@@ -11,14 +11,14 @@ namespace libtensor {
 **/
 class btod_mult1_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(bool, bool) throw(libtest::test_exception);
-    void test_2(bool, bool) throw(libtest::test_exception);
-    void test_3(bool, bool) throw(libtest::test_exception);
-    void test_4(bool, bool) throw(libtest::test_exception);
-    void test_5(bool, bool) throw(libtest::test_exception);
+    void test_1(bool, bool);
+    void test_2(bool, bool);
+    void test_3(bool, bool);
+    void test_4(bool, bool);
+    void test_5(bool, bool);
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_mult_test.C
+++ b/tests/block_tensor/btod_mult_test.C
@@ -18,7 +18,7 @@
 namespace libtensor {
 
 
-void btod_mult_test::perform() throw(libtest::test_exception) {
+void btod_mult_test::perform() {
 
     allocator<double>::init();
 
@@ -90,7 +90,7 @@ void btod_mult_test::perform() throw(libtest::test_exception) {
         and no zero blocks.
  **/
 void btod_mult_test::test_1(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     std::ostringstream oss;
     oss << "btod_mult_test::test_1("
@@ -151,7 +151,7 @@ void btod_mult_test::test_1(
         with no symmetry and no zero blocks, second tensor permuted
  **/
 void btod_mult_test::test_2(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     static const char *testname = "btod_mult_test::test_2";
     std::ostringstream oss;
@@ -215,7 +215,7 @@ void btod_mult_test::test_2(
          symmetry and zero blocks.
  **/
 void btod_mult_test::test_3(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     static const char *testname = "btod_mult_test::test_3";
     std::ostringstream oss;
@@ -304,7 +304,7 @@ void btod_mult_test::test_3(
         with symmetry and zero blocks.
  **/
 void btod_mult_test::test_4(
-        bool recip, bool doadd) throw(libtest::test_exception) {
+        bool recip, bool doadd) {
 
     static const char *testname = "btod_mult_test::test_4";
     std::ostringstream oss;
@@ -395,7 +395,7 @@ void btod_mult_test::test_4(
         with permutational symmetry and anti-symmetry.
         Test for the right result symmetry!
  **/
-void btod_mult_test::test_5(bool symm1, bool symm2) throw(libtest::test_exception) {
+void btod_mult_test::test_5(bool symm1, bool symm2) {
 
     std::ostringstream testname;
     testname << "btod_mult_test::test_5("
@@ -496,7 +496,7 @@ void btod_mult_test::test_5(bool symm1, bool symm2) throw(libtest::test_exceptio
         with permutational symmetry and anti-symmetry.
         Test for the right result symmetry!
  **/
-void btod_mult_test::test_6(bool symm1, bool symm2) throw(libtest::test_exception) {
+void btod_mult_test::test_6(bool symm1, bool symm2) {
 
     std::ostringstream testname;
     testname << "btod_mult_test::test_6("
@@ -601,7 +601,7 @@ void btod_mult_test::test_6(bool symm1, bool symm2) throw(libtest::test_exceptio
         with permutational symmetry and anti-symmetry and se_part / se_label.
  **/
 void btod_mult_test::test_7(bool label, bool part,
-        bool samesym, bool recip, bool doadd) throw(libtest::test_exception) {
+        bool samesym, bool recip, bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_mult_test::test_7(" << label << ", " << part << ", "
@@ -811,7 +811,7 @@ void btod_mult_test::test_7(bool label, bool part,
 /** \test Elementwise division of two 2-order tensors having 1 element blocks.
  **/
 void btod_mult_test::test_8a(bool label, bool part)
-        throw(libtest::test_exception) {
+        {
 
     std::ostringstream tnss;
     tnss << "btod_mult_test::test_8a(" << label << ", " << part << ")";
@@ -936,7 +936,7 @@ void btod_mult_test::test_8a(bool label, bool part)
 /** \test Elementwise division of two 4-order tensors having 1 element blocks.
  **/
 void btod_mult_test::test_8b(bool label, bool part)
-        throw(libtest::test_exception) {
+        {
 
     std::ostringstream tnss;
     tnss << "btod_mult_test::test_8b(" << label << ", " << part << ")";

--- a/tests/block_tensor/btod_mult_test.h
+++ b/tests/block_tensor/btod_mult_test.h
@@ -11,19 +11,19 @@ namespace libtensor {
 **/
 class btod_mult_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(bool recip, bool doadd) throw(libtest::test_exception);
-    void test_2(bool recip, bool doadd) throw(libtest::test_exception);
-    void test_3(bool recip, bool doadd) throw(libtest::test_exception);
-    void test_4(bool recip, bool doadd) throw(libtest::test_exception);
-    void test_5(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_6(bool symm1, bool symm2) throw(libtest::test_exception);
+    void test_1(bool recip, bool doadd);
+    void test_2(bool recip, bool doadd);
+    void test_3(bool recip, bool doadd);
+    void test_4(bool recip, bool doadd);
+    void test_5(bool symm1, bool symm2);
+    void test_6(bool symm1, bool symm2);
     void test_7(bool label, bool part, bool asymm,
-            bool recip, bool add) throw(libtest::test_exception);
-    void test_8a(bool label, bool part) throw(libtest::test_exception);
-    void test_8b(bool label, bool part) throw(libtest::test_exception);
+            bool recip, bool add);
+    void test_8a(bool label, bool part);
+    void test_8b(bool label, bool part);
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_print_test.C
+++ b/tests/block_tensor/btod_print_test.C
@@ -17,7 +17,7 @@
 namespace libtensor {
 
 
-void btod_print_test::perform() throw(libtest::test_exception) {
+void btod_print_test::perform() {
 
     allocator<double>::init();
     try {
@@ -41,7 +41,7 @@ void btod_print_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_1() throw(libtest::test_exception) {
+void btod_print_test::test_1() {
 
     //
     //  Block tensor (2-dim) with one block
@@ -75,7 +75,7 @@ void btod_print_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_2() throw(libtest::test_exception) {
+void btod_print_test::test_2() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension
@@ -113,7 +113,7 @@ void btod_print_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_3() throw(libtest::test_exception) {
+void btod_print_test::test_3() {
 
     //
     //  Block tensor (2-dim) with one zero block
@@ -144,7 +144,7 @@ void btod_print_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_4() throw(libtest::test_exception) {
+void btod_print_test::test_4() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -187,7 +187,7 @@ void btod_print_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_5() throw(libtest::test_exception) {
+void btod_print_test::test_5() {
 
     //
     //  Block tensor (4-dim) with one block
@@ -220,7 +220,7 @@ void btod_print_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_6() throw(libtest::test_exception) {
+void btod_print_test::test_6() {
 
     //
     //  Block tensor (4-dim), two blocks along each dimension (with symmetry)
@@ -258,7 +258,7 @@ void btod_print_test::test_6() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_7() throw(libtest::test_exception) {
+void btod_print_test::test_7() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -296,7 +296,7 @@ void btod_print_test::test_7() throw(libtest::test_exception) {
 }
 
 
-void btod_print_test::test_8() throw(libtest::test_exception) {
+void btod_print_test::test_8() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -332,7 +332,7 @@ void btod_print_test::test_8() throw(libtest::test_exception) {
     }
 }
 
-void btod_print_test::test_9() throw(libtest::test_exception) {
+void btod_print_test::test_9() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -376,7 +376,7 @@ void btod_print_test::test_9() throw(libtest::test_exception) {
     }
 }
 
-void btod_print_test::test_10() throw(libtest::test_exception) {
+void btod_print_test::test_10() {
 
     //
     //  Block tensor (4-dim), two blocks along each dimension,

--- a/tests/block_tensor/btod_print_test.h
+++ b/tests/block_tensor/btod_print_test.h
@@ -11,19 +11,19 @@ namespace libtensor {
  **/
 class btod_print_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
-    void test_10() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
+    void test_9();
+    void test_10();
 
 };
 

--- a/tests/block_tensor/btod_random_test.C
+++ b/tests/block_tensor/btod_random_test.C
@@ -13,7 +13,7 @@
 
 namespace libtensor {
 
-void btod_random_test::perform() throw(libtest::test_exception)
+void btod_random_test::perform()
 {
     allocator<double>::init();
 

--- a/tests/block_tensor/btod_random_test.h
+++ b/tests/block_tensor/btod_random_test.h
@@ -11,7 +11,7 @@ namespace libtensor {
 **/
 class btod_random_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 };
 

--- a/tests/block_tensor/btod_read_test.C
+++ b/tests/block_tensor/btod_read_test.C
@@ -14,7 +14,7 @@
 namespace libtensor {
 
 
-void btod_read_test::perform() throw(libtest::test_exception) {
+void btod_read_test::perform() {
 
     allocator<double>::init();
 
@@ -39,7 +39,7 @@ void btod_read_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_1() throw(libtest::test_exception) {
+void btod_read_test::test_1() {
 
     //
     //  Block tensor (2-dim) with one block
@@ -91,7 +91,7 @@ void btod_read_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_2() throw(libtest::test_exception) {
+void btod_read_test::test_2() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension
@@ -145,7 +145,7 @@ void btod_read_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_3() throw(libtest::test_exception) {
+void btod_read_test::test_3() {
 
     //
     //  Block tensor (2-dim) with one zero block
@@ -196,7 +196,7 @@ void btod_read_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_4() throw(libtest::test_exception) {
+void btod_read_test::test_4() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -256,7 +256,7 @@ void btod_read_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_5() throw(libtest::test_exception) {
+void btod_read_test::test_5() {
 
     //
     //  Block tensor (4-dim) with one block
@@ -303,7 +303,7 @@ void btod_read_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_6() throw(libtest::test_exception) {
+void btod_read_test::test_6() {
 
     //
     //  Block tensor (4-dim), two blocks along each dimension
@@ -355,7 +355,7 @@ void btod_read_test::test_6() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_7() throw(libtest::test_exception) {
+void btod_read_test::test_7() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -410,7 +410,7 @@ void btod_read_test::test_7() throw(libtest::test_exception) {
 }
 
 
-void btod_read_test::test_8() throw(libtest::test_exception) {
+void btod_read_test::test_8() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -464,7 +464,7 @@ void btod_read_test::test_8() throw(libtest::test_exception) {
     }
 }
 
-void btod_read_test::test_9() throw(libtest::test_exception) {
+void btod_read_test::test_9() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,
@@ -542,7 +542,7 @@ void btod_read_test::test_9() throw(libtest::test_exception) {
     }
 }
 
-void btod_read_test::test_10() throw(libtest::test_exception) {
+void btod_read_test::test_10() {
 
     //
     //  Block tensor (2-dim), two blocks along each dimension,

--- a/tests/block_tensor/btod_read_test.h
+++ b/tests/block_tensor/btod_read_test.h
@@ -11,19 +11,19 @@ namespace libtensor {
  **/
 class btod_read_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
-    void test_10() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
+    void test_9();
+    void test_10();
 
 };
 

--- a/tests/block_tensor/btod_scale_test.C
+++ b/tests/block_tensor/btod_scale_test.C
@@ -16,7 +16,7 @@ namespace libtensor {
 typedef allocator<double> allocator_t;
 
 
-void btod_scale_test::perform() throw(libtest::test_exception) {
+void btod_scale_test::perform() {
 
     allocator<double>::init();
     try {
@@ -39,7 +39,7 @@ void btod_scale_test::perform() throw(libtest::test_exception) {
 template<size_t N>
 void btod_scale_test::test_generic(
     const char *testname, block_tensor_i<N, double> &bt, double c)
-    throw(libtest::test_exception) {
+    {
 
     try {
 
@@ -61,7 +61,7 @@ void btod_scale_test::test_generic(
 
 /** \test Checks that scaling by zero results in all zero blocks
  **/
-void btod_scale_test::test_0() throw(libtest::test_exception) {
+void btod_scale_test::test_0() {
 
     static const char *testname = "btod_scale_test::test_0()";
 
@@ -113,7 +113,7 @@ void btod_scale_test::test_0() throw(libtest::test_exception) {
 /** \test Checks the scaling and the zero-block structure of one-dim
         tensors
  **/
-void btod_scale_test::test_i(size_t i) throw(libtest::test_exception) {
+void btod_scale_test::test_i(size_t i) {
 
     std::ostringstream ss;
     ss << "btod_scale_test::test_i(" << i << ")";
@@ -194,7 +194,7 @@ void btod_scale_test::test_i(size_t i) throw(libtest::test_exception) {
 /** \test Tests proper scaling in block tensors with permutational
         %symmetry and anti-symmetry.
  **/
-void btod_scale_test::test_1() throw(libtest::test_exception) {
+void btod_scale_test::test_1() {
 
     static const char *testname = "btod_scale_test::test_1()";
 

--- a/tests/block_tensor/btod_scale_test.h
+++ b/tests/block_tensor/btod_scale_test.h
@@ -12,18 +12,18 @@ namespace libtensor {
 **/
 class btod_scale_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     template<size_t N>
     void test_generic(const char *testname,
         block_tensor_i<N, double> &bt, double c)
-        throw(libtest::test_exception);
+       ;
 
-    void test_0() throw(libtest::test_exception);
-    void test_i(size_t i) throw(libtest::test_exception);
+    void test_0();
+    void test_i(size_t i);
 
-    void test_1() throw(libtest::test_exception);
+    void test_1();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_select_test.C
+++ b/tests/block_tensor/btod_select_test.C
@@ -22,7 +22,7 @@
 namespace libtensor {
 
 
-void btod_select_test::perform() throw(libtest::test_exception) {
+void btod_select_test::perform() {
 
     allocator<double>::init();
 
@@ -94,7 +94,7 @@ void btod_select_test::perform() throw(libtest::test_exception) {
 /** \test Selecting elements from random block tensor (1 block)
  **/
 template<typename ComparePolicy>
-void btod_select_test::test_1(size_t n) throw(libtest::test_exception) {
+void btod_select_test::test_1(size_t n) {
 
     static const char *testname = "btod_select_test::test_1(size_t)";
 
@@ -158,7 +158,7 @@ void btod_select_test::test_1(size_t n) throw(libtest::test_exception) {
 /** \test Selecting elements from random block tensor (multiple blocks)
  **/
 template<typename ComparePolicy>
-void btod_select_test::test_2(size_t n) throw(libtest::test_exception) {
+void btod_select_test::test_2(size_t n) {
 
     static const char *testname = "btod_select_test::test_2(size_t)";
 
@@ -227,7 +227,7 @@ void btod_select_test::test_2(size_t n) throw(libtest::test_exception) {
  **/
 template<typename ComparePolicy>
 void btod_select_test::test_3a(size_t n,
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     static const char *testname = "btod_select_test::test_3a(size_t)";
 
@@ -322,7 +322,7 @@ void btod_select_test::test_3a(size_t n,
 /** \test Selecting elements from random block tensor with label symmetry
  **/
 template<typename ComparePolicy>
-void btod_select_test::test_3b(size_t n) throw(libtest::test_exception) {
+void btod_select_test::test_3b(size_t n) {
 
     static const char *testname = "btod_select_test::test_3b(size_t)";
 
@@ -422,7 +422,7 @@ void btod_select_test::test_3b(size_t n) throw(libtest::test_exception) {
  **/
 template<typename ComparePolicy>
 void btod_select_test::test_3c(size_t n,
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     static const char *testname = "btod_select_test::test_3c(size_t, bool)";
 
@@ -540,7 +540,7 @@ void btod_select_test::test_3c(size_t n,
  **/
 template<typename ComparePolicy>
 void btod_select_test::test_4a(size_t n,
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     static const char *testname = "btod_select_test::test_4a(size_t, bool)";
 
@@ -617,7 +617,7 @@ void btod_select_test::test_4a(size_t n,
       but label symmetry imposed.
  **/
 template<typename ComparePolicy>
-void btod_select_test::test_4b(size_t n) throw(libtest::test_exception) {
+void btod_select_test::test_4b(size_t n) {
 
     static const char *testname = "btod_select_test::test_4(size_t)";
 
@@ -699,7 +699,7 @@ void btod_select_test::test_4b(size_t n) throw(libtest::test_exception) {
  **/
 template<typename ComparePolicy>
 void btod_select_test::test_4c(size_t n,
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     static const char *testname = "btod_select_test::test_4c(size_t, bool)";
 
@@ -781,7 +781,7 @@ void btod_select_test::test_4c(size_t n,
       and different symmetry imposed.
  **/
 template<typename ComparePolicy>
-void btod_select_test::test_5(size_t n) throw(libtest::test_exception) {
+void btod_select_test::test_5(size_t n) {
 
     static const char *testname = "btod_select_test::test_5(size_t)";
 

--- a/tests/block_tensor/btod_select_test.h
+++ b/tests/block_tensor/btod_select_test.h
@@ -11,27 +11,27 @@ namespace libtensor {
 **/
 class btod_select_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     template<typename ComparePolicy>
-    void test_1(size_t n) throw(libtest::test_exception);
+    void test_1(size_t n);
     template<typename ComparePolicy>
-    void test_2(size_t n) throw(libtest::test_exception);
+    void test_2(size_t n);
     template<typename ComparePolicy>
-    void test_3a(size_t n, bool symm) throw(libtest::test_exception);
+    void test_3a(size_t n, bool symm);
     template<typename ComparePolicy>
-    void test_3b(size_t n) throw(libtest::test_exception);
+    void test_3b(size_t n);
     template<typename ComparePolicy>
-    void test_3c(size_t n, bool symm) throw(libtest::test_exception);
+    void test_3c(size_t n, bool symm);
     template<typename ComparePolicy>
-    void test_4a(size_t n, bool symm) throw(libtest::test_exception);
+    void test_4a(size_t n, bool symm);
     template<typename ComparePolicy>
-    void test_4b(size_t n) throw(libtest::test_exception);
+    void test_4b(size_t n);
     template<typename ComparePolicy>
-    void test_4c(size_t n, bool symm) throw(libtest::test_exception);
+    void test_4c(size_t n, bool symm);
     template<typename ComparePolicy>
-    void test_5(size_t n) throw(libtest::test_exception);
+    void test_5(size_t n);
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_set_diag_test.C
+++ b/tests/block_tensor/btod_set_diag_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void btod_set_diag_test::perform() throw(libtest::test_exception) {
+void btod_set_diag_test::perform() {
 
     allocator<double>::init();
 
@@ -35,7 +35,7 @@ void btod_set_diag_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_set_diag_test::test_1() throw(libtest::test_exception) {
+void btod_set_diag_test::test_1() {
 
     static const char *testname = "btod_set_diag_test::test_1()";
 
@@ -53,7 +53,7 @@ void btod_set_diag_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void btod_set_diag_test::test_2() throw(libtest::test_exception) {
+void btod_set_diag_test::test_2() {
 
     static const char *testname = "btod_set_diag_test::test_2()";
 
@@ -76,7 +76,7 @@ void btod_set_diag_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void btod_set_diag_test::test_3() throw(libtest::test_exception) {
+void btod_set_diag_test::test_3() {
 
     static const char *testname = "btod_set_diag_test::test_3()";
 
@@ -100,7 +100,7 @@ void btod_set_diag_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void btod_set_diag_test::test_4() throw(libtest::test_exception) {
+void btod_set_diag_test::test_4() {
 
     static const char *testname = "btod_set_diag_test::test_4()";
 
@@ -130,7 +130,7 @@ void btod_set_diag_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void btod_set_diag_test::test_5() throw(libtest::test_exception) {
+void btod_set_diag_test::test_5() {
 
     static const char *testname = "btod_set_diag_test::test_5()";
 
@@ -164,7 +164,7 @@ void btod_set_diag_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void btod_set_diag_test::test_6() throw(libtest::test_exception) {
+void btod_set_diag_test::test_6() {
 
     static const char *testname = "btod_set_diag_test::test_6()";
 
@@ -195,7 +195,7 @@ void btod_set_diag_test::test_6() throw(libtest::test_exception) {
 template<size_t N>
 void btod_set_diag_test::test_generic(const char *testname,
     const block_index_space<N> &bis, const symmetry<N, double> &sym,
-    double d) throw(libtest::test_exception) {
+    double d) {
 
     typedef allocator<double> allocator_t;
 
@@ -232,7 +232,7 @@ void btod_set_diag_test::test_generic(const char *testname,
 template<size_t N>
 void btod_set_diag_test::test_generic(const char *testname,
     const block_index_space<N> &bis, const symmetry<N, double> &sym,
-    const sequence<N, size_t> &msk, double d) throw(libtest::test_exception) {
+    const sequence<N, size_t> &msk, double d) {
 
     typedef allocator<double> allocator_t;
 

--- a/tests/block_tensor/btod_set_diag_test.h
+++ b/tests/block_tensor/btod_set_diag_test.h
@@ -13,26 +13,26 @@ namespace libtensor {
 **/
 class btod_set_diag_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
 
     template<size_t N>
     void test_generic(const char *testname, const block_index_space<N> &bis,
         const symmetry<N, double> &sym, double d)
-        throw(libtest::test_exception);
+       ;
 
     template<size_t N>
     void test_generic(const char *testname,
         const block_index_space<N> &bis, const symmetry<N, double> &sym,
         const sequence<N, size_t> &msk, double d)
-        throw(libtest::test_exception);
+       ;
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_set_elem_test.C
+++ b/tests/block_tensor/btod_set_elem_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void btod_set_elem_test::perform() throw(libtest::test_exception) {
+void btod_set_elem_test::perform() {
 
     allocator<double>::init();
     try {
@@ -30,7 +30,7 @@ void btod_set_elem_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_set_elem_test::test_1() throw(libtest::test_exception) {
+void btod_set_elem_test::test_1() {
 
     static const char *testname = "btod_set_elem_test::test_1()";
 
@@ -72,7 +72,7 @@ void btod_set_elem_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void btod_set_elem_test::test_2() throw(libtest::test_exception) {
+void btod_set_elem_test::test_2() {
 
     static const char *testname = "btod_set_elem_test::test_2()";
 
@@ -138,7 +138,7 @@ void btod_set_elem_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void btod_set_elem_test::test_3() throw(libtest::test_exception) {
+void btod_set_elem_test::test_3() {
 
     static const char *testname = "btod_set_elem_test::test_3()";
 

--- a/tests/block_tensor/btod_set_elem_test.h
+++ b/tests/block_tensor/btod_set_elem_test.h
@@ -11,12 +11,12 @@ namespace libtensor {
 **/
 class btod_set_elem_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_set_test.C
+++ b/tests/block_tensor/btod_set_test.C
@@ -11,7 +11,7 @@
 namespace libtensor {
 
 
-void btod_set_test::perform() throw(libtest::test_exception) {
+void btod_set_test::perform() {
 
     allocator<double>::init();
     try {
@@ -29,7 +29,7 @@ void btod_set_test::perform() throw(libtest::test_exception) {
 
 /** \test Sets all elements of an empty block %tensor to 1.0.
  **/
-void btod_set_test::test_1() throw(libtest::test_exception) {
+void btod_set_test::test_1() {
 
     static const char *testname = "btod_set_test::test_1()";
 
@@ -67,7 +67,7 @@ void btod_set_test::test_1() throw(libtest::test_exception) {
 
 /** \test Sets all elements of a non-empty block %tensor to 1.0.
  **/
-void btod_set_test::test_2() throw(libtest::test_exception) {
+void btod_set_test::test_2() {
 
     static const char *testname = "btod_set_test::test_2()";
 

--- a/tests/block_tensor/btod_set_test.h
+++ b/tests/block_tensor/btod_set_test.h
@@ -11,11 +11,11 @@ namespace libtensor {
 **/
 class btod_set_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_shift_diag_test.C
+++ b/tests/block_tensor/btod_shift_diag_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void btod_shift_diag_test::perform() throw(libtest::test_exception) {
+void btod_shift_diag_test::perform() {
 
     allocator<double>::init();
 
@@ -35,7 +35,7 @@ void btod_shift_diag_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_shift_diag_test::test_1() throw(libtest::test_exception) {
+void btod_shift_diag_test::test_1() {
 
     static const char *testname = "btod_shift_diag_test::test_1()";
 
@@ -51,7 +51,7 @@ void btod_shift_diag_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void btod_shift_diag_test::test_2() throw(libtest::test_exception) {
+void btod_shift_diag_test::test_2() {
 
     static const char *testname = "btod_shift_diag_test::test_2()";
 
@@ -72,7 +72,7 @@ void btod_shift_diag_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void btod_shift_diag_test::test_3() throw(libtest::test_exception) {
+void btod_shift_diag_test::test_3() {
 
     static const char *testname = "btod_shift_diag_test::test_3()";
 
@@ -94,7 +94,7 @@ void btod_shift_diag_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void btod_shift_diag_test::test_4() throw(libtest::test_exception) {
+void btod_shift_diag_test::test_4() {
 
     static const char *testname = "btod_shift_diag_test::test_4()";
 
@@ -122,7 +122,7 @@ void btod_shift_diag_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void btod_shift_diag_test::test_5() throw(libtest::test_exception) {
+void btod_shift_diag_test::test_5() {
 
     static const char *testname = "btod_shift_diag_test::test_5()";
 
@@ -154,7 +154,7 @@ void btod_shift_diag_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void btod_shift_diag_test::test_6() throw(libtest::test_exception) {
+void btod_shift_diag_test::test_6() {
 
     static const char *testname = "btod_shift_diag_test::test_6()";
 
@@ -183,7 +183,7 @@ void btod_shift_diag_test::test_6() throw(libtest::test_exception) {
 template<size_t N>
 void btod_shift_diag_test::test_generic(const char *testname,
     const block_index_space<N> &bis, const symmetry<N, double> &sym,
-    const sequence<N, size_t> &msk, double d) throw(libtest::test_exception) {
+    const sequence<N, size_t> &msk, double d) {
 
     typedef allocator<double> allocator_t;
 

--- a/tests/block_tensor/btod_shift_diag_test.h
+++ b/tests/block_tensor/btod_shift_diag_test.h
@@ -13,21 +13,21 @@ namespace libtensor {
 **/
 class btod_shift_diag_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
 
     template<size_t N>
     void test_generic(const char *testname,
         const block_index_space<N> &bis, const symmetry<N, double> &sym,
         const sequence<N, size_t> &msk, double d)
-        throw(libtest::test_exception);
+       ;
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_sum_test.C
+++ b/tests/block_tensor/btod_sum_test.C
@@ -13,7 +13,7 @@
 
 namespace libtensor {
 
-void btod_sum_test::perform() throw(libtest::test_exception) {
+void btod_sum_test::perform() {
 
     allocator<double>::init();
 
@@ -42,7 +42,7 @@ void btod_sum_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_1() throw(libtest::test_exception) {
+void btod_sum_test::test_1() {
 
     //
     //  Single operand A + B
@@ -83,7 +83,7 @@ void btod_sum_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_2() throw(libtest::test_exception) {
+void btod_sum_test::test_2() {
 
     //
     //  Two operands: A + B and C + D
@@ -134,7 +134,7 @@ void btod_sum_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_3() throw(libtest::test_exception) {
+void btod_sum_test::test_3() {
 
     //
     //  Two operands: A + B and C + D
@@ -183,7 +183,7 @@ void btod_sum_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_4() throw(libtest::test_exception) {
+void btod_sum_test::test_4() {
 
     //
     //  Two operands: A and C + D
@@ -235,7 +235,7 @@ void btod_sum_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_5() throw(libtest::test_exception) {
+void btod_sum_test::test_5() {
 
     //
     //  Single operand A * B
@@ -302,7 +302,7 @@ void btod_sum_test::test_5() throw(libtest::test_exception) {
     }
 }
 
-void btod_sum_test::test_6(bool do_add) throw(libtest::test_exception) {
+void btod_sum_test::test_6(bool do_add) {
 
     //
     //  Two operands A + B and C + D, symmetry
@@ -394,7 +394,7 @@ void btod_sum_test::test_6(bool do_add) throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_7() throw(libtest::test_exception) {
+void btod_sum_test::test_7() {
 
     //
     //  Single operand A + B, permutational symmetry
@@ -453,7 +453,7 @@ void btod_sum_test::test_7() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_8() throw(libtest::test_exception) {
+void btod_sum_test::test_8() {
 
     //
     //  Two operands with different permutational symmetry
@@ -510,7 +510,7 @@ void btod_sum_test::test_8() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_9a() throw(libtest::test_exception) {
+void btod_sum_test::test_9a() {
 
     //
     //  tt_oovv(i|j|a|b) = t2(i|j|a|b) - t1(j|a)*t1(i|b);
@@ -576,7 +576,7 @@ void btod_sum_test::test_9a() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_9b() throw(libtest::test_exception) {
+void btod_sum_test::test_9b() {
 
     //
     //  tt_oovv(i|j|a|b) = t2(i|j|a|b) - t1(j|a)*t1(i|b);
@@ -656,7 +656,7 @@ void btod_sum_test::test_9b() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_10a() throw(libtest::test_exception) {
+void btod_sum_test::test_10a() {
 
     //
     //  Two operands: A and B, uneven block index space splits
@@ -703,7 +703,7 @@ void btod_sum_test::test_10a() throw(libtest::test_exception) {
 }
 
 
-void btod_sum_test::test_10b() throw(libtest::test_exception) {
+void btod_sum_test::test_10b() {
 
     //
     //  Two operands: A and B, uneven block index space splits

--- a/tests/block_tensor/btod_sum_test.h
+++ b/tests/block_tensor/btod_sum_test.h
@@ -11,21 +11,21 @@ namespace libtensor {
 **/
 class btod_sum_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6(bool do_add) throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9a() throw(libtest::test_exception);
-    void test_9b() throw(libtest::test_exception);
-    void test_10a() throw(libtest::test_exception);
-    void test_10b() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6(bool do_add);
+    void test_7();
+    void test_8();
+    void test_9a();
+    void test_9b();
+    void test_10a();
+    void test_10b();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_symcontract3_test.C
+++ b/tests/block_tensor/btod_symcontract3_test.C
@@ -18,7 +18,7 @@
 namespace libtensor {
 
 
-void btod_symcontract3_test::perform() throw(libtest::test_exception) {
+void btod_symcontract3_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/block_tensor/btod_symcontract3_test.h
+++ b/tests/block_tensor/btod_symcontract3_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class btod_symcontract3_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_contr_1();

--- a/tests/block_tensor/btod_symmetrize2_test.C
+++ b/tests/block_tensor/btod_symmetrize2_test.C
@@ -20,7 +20,7 @@
 namespace libtensor {
 
 
-void btod_symmetrize2_test::perform() throw(libtest::test_exception) {
+void btod_symmetrize2_test::perform() {
 
     allocator<double>::init();
 
@@ -68,7 +68,7 @@ void btod_symmetrize2_test::perform() throw(libtest::test_exception) {
 
 /** \test Symmetrization of a non-symmetric 2-index block %tensor
  **/
-void btod_symmetrize2_test::test_1() throw(libtest::test_exception) {
+void btod_symmetrize2_test::test_1() {
 
     static const char *testname = "btod_symmetrize2_test::test_1()";
 
@@ -130,7 +130,7 @@ void btod_symmetrize2_test::test_1() throw(libtest::test_exception) {
 
 /** \test Anti-symmetrization of a non-symmetric 2-index block %tensor
  **/
-void btod_symmetrize2_test::test_2() throw(libtest::test_exception) {
+void btod_symmetrize2_test::test_2() {
 
     static const char *testname = "btod_symmetrize2_test::test_2()";
 
@@ -193,7 +193,7 @@ void btod_symmetrize2_test::test_2() throw(libtest::test_exception) {
 /** \test Anti-symmetrization of S(-)2*C1*C1 to S(-)2*S(-)2
         in a 4-index block %tensor
  **/
-void btod_symmetrize2_test::test_3() throw(libtest::test_exception) {
+void btod_symmetrize2_test::test_3() {
 
     static const char *testname = "btod_symmetrize2_test::test_3()";
 
@@ -265,7 +265,7 @@ void btod_symmetrize2_test::test_3() throw(libtest::test_exception) {
 
 /** \test Symmetrization of S2*S2 to S2*C1*C1 in a 4-index block %tensor
  **/
-void btod_symmetrize2_test::test_4() throw(libtest::test_exception) {
+void btod_symmetrize2_test::test_4() {
 
     static const char *testname = "btod_symmetrize2_test::test_4()";
 
@@ -335,7 +335,7 @@ void btod_symmetrize2_test::test_4() throw(libtest::test_exception) {
 /** \test Symmetrization of two pairs of indexes in a non-symmetric
         4-index block %tensor
  **/
-void btod_symmetrize2_test::test_5(bool symm) throw(libtest::test_exception) {
+void btod_symmetrize2_test::test_5(bool symm) {
 
     static const char *testname = "btod_symmetrize2_test::test_5(bool)";
 
@@ -402,7 +402,7 @@ void btod_symmetrize2_test::test_5(bool symm) throw(libtest::test_exception) {
         2-dim block %tensor with se_label, se_part
  **/
 void btod_symmetrize2_test::test_6a(bool symm, bool label,
-        bool part, bool doadd) throw(libtest::test_exception) {
+        bool part, bool doadd) {
 
     std::ostringstream tnss;
     tnss << "btod_symmetrize2_test::test_6a(" << symm << ", "
@@ -525,7 +525,7 @@ void btod_symmetrize2_test::test_6a(bool symm, bool label,
         4-dim block %tensor with se_label, se_part
  **/
 void btod_symmetrize2_test::test_6b(bool symm, bool label,
-        bool part) throw(libtest::test_exception) {
+        bool part) {
 
     std::ostringstream tnss;
     tnss << "btod_symmetrize2_test::test_6b(" << symm << ", "

--- a/tests/block_tensor/btod_symmetrize2_test.h
+++ b/tests/block_tensor/btod_symmetrize2_test.h
@@ -12,18 +12,18 @@ namespace libtensor {
  **/
 class btod_symmetrize2_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5(bool symm) throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5(bool symm);
     void test_6a(bool symm, bool label,
-            bool part, bool doadd) throw(libtest::test_exception);
+            bool part, bool doadd);
     void test_6b(bool symm, bool label,
-            bool part) throw(libtest::test_exception);
+            bool part);
     void test_7();
 
 };

--- a/tests/block_tensor/btod_symmetrize3_test.C
+++ b/tests/block_tensor/btod_symmetrize3_test.C
@@ -18,7 +18,7 @@
 namespace libtensor {
 
 
-void btod_symmetrize3_test::perform() throw(libtest::test_exception) {
+void btod_symmetrize3_test::perform() {
 
     allocator<double>::init();
 
@@ -48,7 +48,7 @@ void btod_symmetrize3_test::perform() throw(libtest::test_exception) {
 /** \test Symmetrization of a non-symmetric 3-index block %tensor
         over three indexes
  **/
-void btod_symmetrize3_test::test_1() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_1() {
 
     static const char *testname = "btod_symmetrize3_test::test_1()";
 
@@ -121,7 +121,7 @@ void btod_symmetrize3_test::test_1() throw(libtest::test_exception) {
 /** \test Anti-symmetrization of a non-symmetric 3-index block %tensor
         over three indexes
  **/
-void btod_symmetrize3_test::test_2() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_2() {
 
     static const char *testname = "btod_symmetrize3_test::test_2()";
 
@@ -191,7 +191,7 @@ void btod_symmetrize3_test::test_2() throw(libtest::test_exception) {
 /** \test Symmetrization of a 3-index block %tensor with S(+)2*C1
         over three indexes
  **/
-void btod_symmetrize3_test::test_3() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_3() {
 
     static const char *testname = "btod_symmetrize3_test::test_3()";
 
@@ -266,7 +266,7 @@ void btod_symmetrize3_test::test_3() throw(libtest::test_exception) {
 /** \test Symmetrization of a 4-index block %tensor with S(+)2*C1
         over three indexes
  **/
-void btod_symmetrize3_test::test_4() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_4() {
 
     static const char *testname = "btod_symmetrize3_test::test_4()";
 
@@ -341,7 +341,7 @@ void btod_symmetrize3_test::test_4() throw(libtest::test_exception) {
 /** \test Symmetrization of a 3-index block %tensor with partitions
         over three indexes
  **/
-void btod_symmetrize3_test::test_5() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_5() {
 
     static const char *testname = "btod_symmetrize3_test::test_5()";
 
@@ -444,7 +444,7 @@ void btod_symmetrize3_test::test_5() throw(libtest::test_exception) {
 /** \test Double anti-symmetrization of a 6-index block %tensor with
         S(-)2*C1*C1*S(-)2 over three indexes
  **/
-void btod_symmetrize3_test::test_6() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_6() {
 
     static const char *testname = "btod_symmetrize3_test::test_6()";
 
@@ -531,7 +531,7 @@ void btod_symmetrize3_test::test_6() throw(libtest::test_exception) {
 /** \test Double anti-symmetrization of a 6-index block %tensor with
         S(-)2*C1*C1*S(-)2 over three indexes (additive)
  **/
-void btod_symmetrize3_test::test_7() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_7() {
 
     static const char *testname = "btod_symmetrize3_test::test_7()";
 
@@ -627,7 +627,7 @@ void btod_symmetrize3_test::test_7() throw(libtest::test_exception) {
 
 /** \test Anti-symmetrization of a contraction that appears in CCSD(T)
  **/
-void btod_symmetrize3_test::test_8a() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_8a() {
 
     static const char *testname = "btod_symmetrize3_test::test_8a()";
 
@@ -752,7 +752,7 @@ void btod_symmetrize3_test::test_8a() throw(libtest::test_exception) {
 /** \test Anti-symmetrization of a contraction that appears in CCSD(T),
         invoked blockwise
  **/
-void btod_symmetrize3_test::test_8b() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_8b() {
 
     static const char *testname = "btod_symmetrize3_test::test_8b()";
 
@@ -877,7 +877,7 @@ void btod_symmetrize3_test::test_8b() throw(libtest::test_exception) {
 /** \test Symmetrization of a 4-index block %tensor with S(+)2*S(+)2
         over three indexes
  **/
-void btod_symmetrize3_test::test_9() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_9() {
 
     static const char *testname = "btod_symmetrize3_test::test_9()";
 
@@ -954,7 +954,7 @@ void btod_symmetrize3_test::test_9() throw(libtest::test_exception) {
 /** \test Symmetrization of a non-symmetric 3-index block %tensor
         over three indexes specified using permutations
  **/
-void btod_symmetrize3_test::test_10() throw(libtest::test_exception) {
+void btod_symmetrize3_test::test_10() {
 
     static const char *testname = "btod_symmetrize3_test::test_10()";
 

--- a/tests/block_tensor/btod_symmetrize3_test.h
+++ b/tests/block_tensor/btod_symmetrize3_test.h
@@ -11,20 +11,20 @@ namespace libtensor {
  **/
 class btod_symmetrize3_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8a() throw(libtest::test_exception);
-    void test_8b() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
-    void test_10() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8a();
+    void test_8b();
+    void test_9();
+    void test_10();
 
 };
 

--- a/tests/block_tensor/btod_symmetrize4_test.C
+++ b/tests/block_tensor/btod_symmetrize4_test.C
@@ -18,7 +18,7 @@
 namespace libtensor {
 
 
-void btod_symmetrize4_test::perform() throw(libtest::test_exception) {
+void btod_symmetrize4_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/block_tensor/btod_symmetrize4_test.h
+++ b/tests/block_tensor/btod_symmetrize4_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
  **/
 class btod_symmetrize4_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/block_tensor/btod_trace_test.C
+++ b/tests/block_tensor/btod_trace_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void btod_trace_test::perform() throw(libtest::test_exception) {
+void btod_trace_test::perform() {
 
     allocator<double>::init();
     try {
@@ -41,7 +41,7 @@ void btod_trace_test::perform() throw(libtest::test_exception) {
 /** \test Computes the trace of a square matrix: \f$ b_i = a_{ii} \f$
         (all zero blocks)
  **/
-void btod_trace_test::test_zero_1() throw(libtest::test_exception) {
+void btod_trace_test::test_zero_1() {
 
     static const char *testname = "btod_trace_test::test_zero_1()";
 
@@ -83,7 +83,7 @@ void btod_trace_test::test_zero_1() throw(libtest::test_exception) {
 /** \test Computes the trace of a square matrix: \f$ d = a_{ii} \f$,
         no symmetry
  **/
-void btod_trace_test::test_nosym_1() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_1() {
 
     static const char *testname = "btod_trace_test::test_nosym_1()";
 
@@ -131,7 +131,7 @@ void btod_trace_test::test_nosym_1() throw(libtest::test_exception) {
 /** \test Computes the trace of a square matrix: \f$ d = a_{ii} \f$,
         no symmetry, sparse blocks
  **/
-void btod_trace_test::test_nosym_1_sp() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_1_sp() {
 
     static const char *testname = "btod_trace_test::test_nosym_1_sp()";
 
@@ -184,7 +184,7 @@ void btod_trace_test::test_nosym_1_sp() throw(libtest::test_exception) {
 /** \test Computes the trace of a square matrix (with permutation):
         \f$ d = a_{ii} \f$, no symmetry
  **/
-void btod_trace_test::test_nosym_2() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_2() {
 
     static const char *testname = "btod_trace_test::test_nosym_2()";
 
@@ -233,7 +233,7 @@ void btod_trace_test::test_nosym_2() throw(libtest::test_exception) {
 /** \test Computes the trace of a matricized 4-index tensor:
         \f$ d = a_{ijij} \f$, no symmetry
  **/
-void btod_trace_test::test_nosym_3() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_3() {
 
     static const char *testname = "btod_trace_test::test_nosym_3()";
 
@@ -284,7 +284,7 @@ void btod_trace_test::test_nosym_3() throw(libtest::test_exception) {
 /** \test Computes the trace of a matricized 4-index tensor
         (with permutation): \f$ d = a_{iijj} \f$, no symmetry
  **/
-void btod_trace_test::test_nosym_4() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_4() {
 
     static const char *testname = "btod_trace_test::test_nosym_4()";
 
@@ -336,7 +336,7 @@ void btod_trace_test::test_nosym_4() throw(libtest::test_exception) {
 /** \test Computes the trace of a square matrix: \f$ d = a_{ii} \f$,
         no symmetry, blocks with unity dimensions
  **/
-void btod_trace_test::test_nosym_5() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_5() {
 
     static const char *testname = "btod_trace_test::test_nosym_5()";
 
@@ -383,7 +383,7 @@ void btod_trace_test::test_nosym_5() throw(libtest::test_exception) {
 /** \test Computes the trace of a matricized 4-index tensor:
         \f$ d = a_{ijij} \f$, no symmetry, blocks with unity dimensions
  **/
-void btod_trace_test::test_nosym_6() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_6() {
 
     static const char *testname = "btod_trace_test::test_nosym_6()";
 
@@ -434,7 +434,7 @@ void btod_trace_test::test_nosym_6() throw(libtest::test_exception) {
 /** \test Computes the trace of a matricized 4-index tensor:
         \f$ d = a_{ijij} \f$, no symmetry, all dimensions are equal
  **/
-void btod_trace_test::test_nosym_7() throw(libtest::test_exception) {
+void btod_trace_test::test_nosym_7() {
 
     static const char *testname = "btod_trace_test::test_nosym_7()";
 
@@ -484,7 +484,7 @@ void btod_trace_test::test_nosym_7() throw(libtest::test_exception) {
 /** \test Computes the trace of a square matrix: \f$ d = a_{ii} \f$,
         perm symmetry
  **/
-void btod_trace_test::test_permsym_1() throw(libtest::test_exception) {
+void btod_trace_test::test_permsym_1() {
 
     static const char *testname = "btod_trace_test::test_permsym_1()";
 
@@ -540,7 +540,7 @@ void btod_trace_test::test_permsym_1() throw(libtest::test_exception) {
 /** \test Computes the trace of a matricized 4-index tensor:
         \f$ d = a_{ijij} \f$, perm symmetry
  **/
-void btod_trace_test::test_permsym_2() throw(libtest::test_exception) {
+void btod_trace_test::test_permsym_2() {
 
     static const char *testname = "btod_trace_test::test_permsym_2()";
 

--- a/tests/block_tensor/btod_trace_test.h
+++ b/tests/block_tensor/btod_trace_test.h
@@ -11,20 +11,20 @@ namespace libtensor {
  **/
 class btod_trace_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_zero_1() throw(libtest::test_exception);
-    void test_nosym_1() throw(libtest::test_exception);
-    void test_nosym_1_sp() throw(libtest::test_exception);
-    void test_nosym_2() throw(libtest::test_exception);
-    void test_nosym_3() throw(libtest::test_exception);
-    void test_nosym_4() throw(libtest::test_exception);
-    void test_nosym_5() throw(libtest::test_exception);
-    void test_nosym_6() throw(libtest::test_exception);
-    void test_nosym_7() throw(libtest::test_exception);
-    void test_permsym_1() throw(libtest::test_exception);
-    void test_permsym_2() throw(libtest::test_exception);
+    void test_zero_1();
+    void test_nosym_1();
+    void test_nosym_1_sp();
+    void test_nosym_2();
+    void test_nosym_3();
+    void test_nosym_4();
+    void test_nosym_5();
+    void test_nosym_6();
+    void test_nosym_7();
+    void test_permsym_1();
+    void test_permsym_2();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_tridiagonalize_test.C
+++ b/tests/block_tensor/btod_tridiagonalize_test.C
@@ -10,7 +10,7 @@
 namespace libtensor {
 
 
-void btod_tridiagonalize_test::perform() throw(libtest::test_exception) {
+void btod_tridiagonalize_test::perform() {
 
     allocator<double>::init();
 
@@ -31,7 +31,7 @@ void btod_tridiagonalize_test::perform() throw(libtest::test_exception) {
 
 /** \tridiagonalize matrix 3x3
  **/
-void btod_tridiagonalize_test::test_1() throw(libtest::test_exception) {
+void btod_tridiagonalize_test::test_1() {
 
     static const char *testname = "btod_tridiagonalize_test::test_1()";
 
@@ -78,7 +78,7 @@ void btod_tridiagonalize_test::test_1() throw(libtest::test_exception) {
 
 /** \tridiagonalize matrix 4x4 with fragmentation
  **/
-void btod_tridiagonalize_test::test_2() throw(libtest::test_exception) {
+void btod_tridiagonalize_test::test_2() {
 
     static const char *testname = "btod_tridiagonalize_test::test_2()";
 
@@ -131,7 +131,7 @@ void btod_tridiagonalize_test::test_2() throw(libtest::test_exception) {
 
 /** \tridiagonalize matrix 5x5 with fragmentation
  **/
-void btod_tridiagonalize_test::test_3() throw(libtest::test_exception) {
+void btod_tridiagonalize_test::test_3() {
 
     static const char *testname = "btod_tridiagonalize_test::test_3()";
 

--- a/tests/block_tensor/btod_tridiagonalize_test.h
+++ b/tests/block_tensor/btod_tridiagonalize_test.h
@@ -11,12 +11,12 @@ namespace libtensor {
 **/
 class btod_tridiagonalize_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
 };
 
 } // namespace libtensor

--- a/tests/block_tensor/btod_vmpriority_test.C
+++ b/tests/block_tensor/btod_vmpriority_test.C
@@ -10,7 +10,7 @@
 namespace libtensor {
 
 
-void btod_vmpriority_test::perform() throw(libtest::test_exception) {
+void btod_vmpriority_test::perform() {
 
     allocator<double>::init();
     try {
@@ -25,7 +25,7 @@ void btod_vmpriority_test::perform() throw(libtest::test_exception) {
 }
 
 
-void btod_vmpriority_test::test_1() throw(libtest::test_exception) {
+void btod_vmpriority_test::test_1() {
 
     static const char *testname = "btod_vmpriority_test::test_1()";
 

--- a/tests/block_tensor/btod_vmpriority_test.h
+++ b/tests/block_tensor/btod_vmpriority_test.h
@@ -12,10 +12,10 @@ namespace libtensor {
  **/
 class btod_vmpriority_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
+    void test_1();
 
 };
 

--- a/tests/block_tensor/direct_block_tensor_test.C
+++ b/tests/block_tensor/direct_block_tensor_test.C
@@ -16,7 +16,7 @@
 namespace libtensor {
 
 
-void direct_block_tensor_test::perform() throw(libtest::test_exception) {
+void direct_block_tensor_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/block_tensor/direct_block_tensor_test.h
+++ b/tests/block_tensor/direct_block_tensor_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class direct_block_tensor_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_op_1();

--- a/tests/block_tensor/gen_bto_aux_add_test.C
+++ b/tests/block_tensor/gen_bto_aux_add_test.C
@@ -16,7 +16,7 @@
 namespace libtensor {
 
 
-void gen_bto_aux_add_test::perform() throw(libtest::test_exception) {
+void gen_bto_aux_add_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/block_tensor/gen_bto_aux_add_test.h
+++ b/tests/block_tensor/gen_bto_aux_add_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
  **/
 class gen_bto_aux_add_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1a();

--- a/tests/block_tensor/gen_bto_aux_copy_test.C
+++ b/tests/block_tensor/gen_bto_aux_copy_test.C
@@ -16,7 +16,7 @@
 namespace libtensor {
 
 
-void gen_bto_aux_copy_test::perform() throw(libtest::test_exception) {
+void gen_bto_aux_copy_test::perform() {
 
     allocator<double>::init::init();
 

--- a/tests/block_tensor/gen_bto_aux_copy_test.h
+++ b/tests/block_tensor/gen_bto_aux_copy_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
  **/
 class gen_bto_aux_copy_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1a();

--- a/tests/block_tensor/gen_bto_contract2_clst_builder_test.C
+++ b/tests/block_tensor/gen_bto_contract2_clst_builder_test.C
@@ -13,7 +13,7 @@ namespace libtensor {
 
 
 void gen_bto_contract2_clst_builder_test::perform()
-    throw(libtest::test_exception) {
+    {
 
     allocator<double>::init();
 

--- a/tests/block_tensor/gen_bto_contract2_clst_builder_test.h
+++ b/tests/block_tensor/gen_bto_contract2_clst_builder_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
  **/
 class gen_bto_contract2_clst_builder_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/block_tensor/gen_bto_dirsum_sym_test.C
+++ b/tests/block_tensor/gen_bto_dirsum_sym_test.C
@@ -11,7 +11,7 @@
 namespace libtensor {
 
 
-void gen_bto_dirsum_sym_test::perform() throw(libtest::test_exception) {
+void gen_bto_dirsum_sym_test::perform() {
 
     test_1();
     test_2();
@@ -20,7 +20,7 @@ void gen_bto_dirsum_sym_test::perform() throw(libtest::test_exception) {
 }
 
 
-void gen_bto_dirsum_sym_test::test_1() throw(libtest::test_exception) {
+void gen_bto_dirsum_sym_test::test_1() {
 
     static const char *testname = "gen_bto_dirsum_sym_test::test_1()";
 
@@ -75,7 +75,7 @@ void gen_bto_dirsum_sym_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void gen_bto_dirsum_sym_test::test_2() throw(libtest::test_exception) {
+void gen_bto_dirsum_sym_test::test_2() {
 
     //
     //  c_ijkl = a_ij + b_kl
@@ -133,7 +133,7 @@ void gen_bto_dirsum_sym_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void gen_bto_dirsum_sym_test::test_3() throw(libtest::test_exception) {
+void gen_bto_dirsum_sym_test::test_3() {
 
     //
     //  c_ijkl = a_ijk + b_l
@@ -202,7 +202,7 @@ void gen_bto_dirsum_sym_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void gen_bto_dirsum_sym_test::test_4() throw(libtest::test_exception) {
+void gen_bto_dirsum_sym_test::test_4() {
 
     //
     //  c_ij = a_i - a_j

--- a/tests/block_tensor/gen_bto_dirsum_sym_test.h
+++ b/tests/block_tensor/gen_bto_dirsum_sym_test.h
@@ -12,13 +12,13 @@ namespace libtensor {
 **/
 class gen_bto_dirsum_sym_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
 
 };
 

--- a/tests/block_tensor/gen_bto_symcontract2_sym_test.C
+++ b/tests/block_tensor/gen_bto_symcontract2_sym_test.C
@@ -12,7 +12,7 @@
 namespace libtensor {
 
 
-void gen_bto_symcontract2_sym_test::perform() throw(libtest::test_exception) {
+void gen_bto_symcontract2_sym_test::perform() {
 
     test_1();
     test_2();

--- a/tests/block_tensor/gen_bto_symcontract2_sym_test.h
+++ b/tests/block_tensor/gen_bto_symcontract2_sym_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class gen_bto_symcontract2_sym_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/block_tensor/gen_bto_unfold_symmetry_test.C
+++ b/tests/block_tensor/gen_bto_unfold_symmetry_test.C
@@ -15,7 +15,7 @@
 namespace libtensor {
 
 
-void gen_bto_unfold_symmetry_test::perform() throw(libtest::test_exception) {
+void gen_bto_unfold_symmetry_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/block_tensor/gen_bto_unfold_symmetry_test.h
+++ b/tests/block_tensor/gen_bto_unfold_symmetry_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
  **/
 class gen_bto_unfold_symmetry_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/expr_tree_test.C
+++ b/tests/expr/expr_tree_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void expr_tree_test::perform() throw(libtest::test_exception) {
+void expr_tree_test::perform() {
 
     test_1();
     test_2();

--- a/tests/expr/expr_tree_test.h
+++ b/tests/expr/expr_tree_test.h
@@ -11,7 +11,7 @@ namespace libtensor {
  **/
 class expr_tree_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/graph_test.C
+++ b/tests/expr/graph_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void graph_test::perform() throw(libtest::test_exception) {
+void graph_test::perform() {
 
     test_1();
     test_2();

--- a/tests/expr/graph_test.h
+++ b/tests/expr/graph_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class graph_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/node_add_test.C
+++ b/tests/expr/node_add_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void node_add_test::perform() throw(libtest::test_exception) {
+void node_add_test::perform() {
 
     test_1();
 }
@@ -16,7 +16,7 @@ void node_add_test::perform() throw(libtest::test_exception) {
 using namespace expr;
 
 
-void node_add_test::test_1() throw(libtest::test_exception) {
+void node_add_test::test_1() {
 
     static const char testname[] = "node_add_test::test_1()";
 

--- a/tests/expr/node_add_test.h
+++ b/tests/expr/node_add_test.h
@@ -12,10 +12,10 @@ namespace libtensor {
 **/
 class node_add_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
+    void test_1();
 
 };
 

--- a/tests/expr/node_contract_test.C
+++ b/tests/expr/node_contract_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void node_contract_test::perform() throw(libtest::test_exception) {
+void node_contract_test::perform() {
 
     test_1();
     test_2();
@@ -17,7 +17,7 @@ void node_contract_test::perform() throw(libtest::test_exception) {
 using namespace expr;
 
 
-void node_contract_test::test_1() throw(libtest::test_exception) {
+void node_contract_test::test_1() {
 
     static const char testname[] = "node_contract_test::test_1()";
 
@@ -49,7 +49,7 @@ void node_contract_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void node_contract_test::test_2() throw(libtest::test_exception) {
+void node_contract_test::test_2() {
 
     static const char testname[] = "node_contract_test::test_2()";
 

--- a/tests/expr/node_contract_test.h
+++ b/tests/expr/node_contract_test.h
@@ -12,11 +12,11 @@ namespace libtensor {
 **/
 class node_contract_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
 
 };
 

--- a/tests/expr/node_diag_test.C
+++ b/tests/expr/node_diag_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void node_diag_test::perform() throw(libtest::test_exception) {
+void node_diag_test::perform() {
 
     test_1();
 }
@@ -16,7 +16,7 @@ void node_diag_test::perform() throw(libtest::test_exception) {
 using namespace expr;
 
 
-void node_diag_test::test_1() throw(libtest::test_exception) {
+void node_diag_test::test_1() {
 
     static const char testname[] = "node_diag_test::test_1()";
 

--- a/tests/expr/node_diag_test.h
+++ b/tests/expr/node_diag_test.h
@@ -12,10 +12,10 @@ namespace libtensor {
 **/
 class node_diag_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
+    void test_1();
 
 };
 

--- a/tests/expr/node_dot_product_test.C
+++ b/tests/expr/node_dot_product_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void node_dot_product_test::perform() throw(libtest::test_exception) {
+void node_dot_product_test::perform() {
 
     test_1();
 }

--- a/tests/expr/node_dot_product_test.h
+++ b/tests/expr/node_dot_product_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class node_dot_product_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/node_ident_any_tensor_test.C
+++ b/tests/expr/node_ident_any_tensor_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void node_ident_any_tensor_test::perform() throw(libtest::test_exception) {
+void node_ident_any_tensor_test::perform() {
 
     test_1();
     test_2();

--- a/tests/expr/node_ident_any_tensor_test.h
+++ b/tests/expr/node_ident_any_tensor_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class node_ident_any_tensor_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/node_product_test.C
+++ b/tests/expr/node_product_test.C
@@ -8,7 +8,7 @@
 namespace libtensor {
 
 
-void node_product_test::perform() throw(libtest::test_exception) {
+void node_product_test::perform() {
 
     test_1();
     test_2();

--- a/tests/expr/node_product_test.h
+++ b/tests/expr/node_product_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class node_product_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/node_scalar_test.C
+++ b/tests/expr/node_scalar_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void node_scalar_test::perform() throw(libtest::test_exception) {
+void node_scalar_test::perform() {
 
     test_1();
 }

--- a/tests/expr/node_scalar_test.h
+++ b/tests/expr/node_scalar_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class node_scalar_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/node_set_test.C
+++ b/tests/expr/node_set_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void node_set_test::perform() throw(libtest::test_exception) {
+void node_set_test::perform() {
 
     test_1();
 }
@@ -16,7 +16,7 @@ void node_set_test::perform() throw(libtest::test_exception) {
 using namespace expr;
 
 
-void node_set_test::test_1() throw(libtest::test_exception) {
+void node_set_test::test_1() {
 
     static const char testname[] = "node_set_test::test_1()";
 

--- a/tests/expr/node_set_test.h
+++ b/tests/expr/node_set_test.h
@@ -12,10 +12,10 @@ namespace libtensor {
 **/
 class node_set_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
+    void test_1();
 
 };
 

--- a/tests/expr/node_trace_test.C
+++ b/tests/expr/node_trace_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void node_trace_test::perform() throw(libtest::test_exception) {
+void node_trace_test::perform() {
 
     test_1();
     test_2();

--- a/tests/expr/node_trace_test.h
+++ b/tests/expr/node_trace_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class node_trace_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/expr/node_transform_test.C
+++ b/tests/expr/node_transform_test.C
@@ -8,7 +8,7 @@
 namespace libtensor {
 
 
-void node_transform_test::perform() throw(libtest::test_exception) {
+void node_transform_test::perform() {
 
     test_1();
 }

--- a/tests/expr/node_transform_test.h
+++ b/tests/expr/node_transform_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class node_transform_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/iface/any_tensor_test.C
+++ b/tests/iface/any_tensor_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void any_tensor_test::perform() throw(libtest::test_exception) {
+void any_tensor_test::perform() {
 
     test_1();
     test_2();

--- a/tests/iface/any_tensor_test.h
+++ b/tests/iface/any_tensor_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class any_tensor_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/iface/bispace_expr_test.C
+++ b/tests/iface/bispace_expr_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void bispace_expr_test::perform() throw(libtest::test_exception) {
+void bispace_expr_test::perform() {
 
     test_sym_1();
     test_sym_2();
@@ -40,7 +40,7 @@ void bispace_expr_test::perform() throw(libtest::test_exception) {
 
 using namespace expr;
 
-void bispace_expr_test::test_sym_1() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_1() {
 
     static const char *testname = "bispace_expr_test::test_sym_1()";
 
@@ -63,7 +63,7 @@ void bispace_expr_test::test_sym_1() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_2() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_2() {
 
     static const char *testname = "bispace_expr_test::test_sym_2()";
 
@@ -100,7 +100,7 @@ void bispace_expr_test::test_sym_2() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_3() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_3() {
 
     static const char *testname = "bispace_expr_test::test_sym_3()";
 
@@ -132,7 +132,7 @@ void bispace_expr_test::test_sym_3() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_4() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_4() {
 
     static const char *testname = "bispace_expr_test::test_sym_4()";
 
@@ -182,7 +182,7 @@ void bispace_expr_test::test_sym_4() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_5() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_5() {
 
     static const char *testname = "bispace_expr_test::test_sym_5()";
 
@@ -232,7 +232,7 @@ void bispace_expr_test::test_sym_5() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_6() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_6() {
 
     static const char *testname = "bispace_expr_test::test_sym_6()";
 
@@ -282,7 +282,7 @@ void bispace_expr_test::test_sym_6() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_7() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_7() {
 
     static const char *testname = "bispace_expr_test::test_sym_7()";
 
@@ -350,7 +350,7 @@ void bispace_expr_test::test_sym_7() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_8() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_8() {
 
     static const char *testname = "bispace_expr_test::test_sym_8()";
 
@@ -418,7 +418,7 @@ void bispace_expr_test::test_sym_8() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_9() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_9() {
 
     static const char *testname = "bispace_expr_test::test_sym_9()";
 
@@ -469,7 +469,7 @@ void bispace_expr_test::test_sym_9() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_sym_10() throw(libtest::test_exception) {
+void bispace_expr_test::test_sym_10() {
 
     static const char *testname = "bispace_expr_test::test_sym_10()";
 
@@ -514,7 +514,7 @@ void bispace_expr_test::test_sym_10() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_contains_1() throw(libtest::test_exception) {
+void bispace_expr_test::test_contains_1() {
 
     static const char *testname = "bispace_expr_test::test_contains_1()";
 
@@ -548,7 +548,7 @@ void bispace_expr_test::test_contains_1() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_contains_2() throw(libtest::test_exception) {
+void bispace_expr_test::test_contains_2() {
 
     static const char *testname = "bispace_expr_test::test_contains_2()";
 
@@ -582,7 +582,7 @@ void bispace_expr_test::test_contains_2() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_contains_3() throw(libtest::test_exception) {
+void bispace_expr_test::test_contains_3() {
 
     static const char *testname = "bispace_expr_test::test_contains_3()";
 
@@ -628,7 +628,7 @@ void bispace_expr_test::test_contains_3() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_contains_4() throw(libtest::test_exception) {
+void bispace_expr_test::test_contains_4() {
 
     static const char *testname = "bispace_expr_test::test_contains_4()";
 
@@ -669,7 +669,7 @@ void bispace_expr_test::test_contains_4() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_locate_1() throw(libtest::test_exception) {
+void bispace_expr_test::test_locate_1() {
 
     static const char *testname = "bispace_expr_test::test_locate_1()";
 
@@ -699,7 +699,7 @@ void bispace_expr_test::test_locate_1() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_locate_2() throw(libtest::test_exception) {
+void bispace_expr_test::test_locate_2() {
 
     static const char *testname = "bispace_expr_test::test_locate_2()";
 
@@ -729,7 +729,7 @@ void bispace_expr_test::test_locate_2() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_locate_3() throw(libtest::test_exception) {
+void bispace_expr_test::test_locate_3() {
 
     static const char *testname = "bispace_expr_test::test_locate_3()";
 
@@ -780,7 +780,7 @@ void bispace_expr_test::test_locate_3() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_locate_4() throw(libtest::test_exception) {
+void bispace_expr_test::test_locate_4() {
 
     static const char *testname = "bispace_expr_test::test_locate_4()";
 
@@ -811,7 +811,7 @@ void bispace_expr_test::test_locate_4() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_perm_1() throw(libtest::test_exception) {
+void bispace_expr_test::test_perm_1() {
 
     static const char *testname = "bispace_expr_test::test_perm_1()";
 
@@ -833,7 +833,7 @@ void bispace_expr_test::test_perm_1() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_perm_2() throw(libtest::test_exception) {
+void bispace_expr_test::test_perm_2() {
 
     static const char *testname = "bispace_expr_test::test_perm_2()";
 
@@ -856,7 +856,7 @@ void bispace_expr_test::test_perm_2() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_perm_3() throw(libtest::test_exception) {
+void bispace_expr_test::test_perm_3() {
 
     static const char *testname = "bispace_expr_test::test_perm_3()";
 
@@ -879,7 +879,7 @@ void bispace_expr_test::test_perm_3() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_perm_4() throw(libtest::test_exception) {
+void bispace_expr_test::test_perm_4() {
 
     static const char *testname = "bispace_expr_test::test_perm_4()";
 
@@ -902,7 +902,7 @@ void bispace_expr_test::test_perm_4() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_perm_5() throw(libtest::test_exception) {
+void bispace_expr_test::test_perm_5() {
 
     static const char *testname = "bispace_expr_test::test_perm_5()";
 
@@ -926,7 +926,7 @@ void bispace_expr_test::test_perm_5() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_perm_6() throw(libtest::test_exception) {
+void bispace_expr_test::test_perm_6() {
 
     static const char *testname = "bispace_expr_test::test_perm_6()";
 
@@ -950,7 +950,7 @@ void bispace_expr_test::test_perm_6() throw(libtest::test_exception) {
 }
 
 
-void bispace_expr_test::test_exc_1() throw(libtest::test_exception) {
+void bispace_expr_test::test_exc_1() {
 
     static const char *testname = "bispace_expr_test::test_exc_1()";
 

--- a/tests/iface/bispace_expr_test.h
+++ b/tests/iface/bispace_expr_test.h
@@ -11,38 +11,38 @@ namespace libtensor {
  **/
 class bispace_expr_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_sym_1() throw(libtest::test_exception);
-    void test_sym_2() throw(libtest::test_exception);
-    void test_sym_3() throw(libtest::test_exception);
-    void test_sym_4() throw(libtest::test_exception);
-    void test_sym_5() throw(libtest::test_exception);
-    void test_sym_6() throw(libtest::test_exception);
-    void test_sym_7() throw(libtest::test_exception);
-    void test_sym_8() throw(libtest::test_exception);
-    void test_sym_9() throw(libtest::test_exception);
-    void test_sym_10() throw(libtest::test_exception);
+    void test_sym_1();
+    void test_sym_2();
+    void test_sym_3();
+    void test_sym_4();
+    void test_sym_5();
+    void test_sym_6();
+    void test_sym_7();
+    void test_sym_8();
+    void test_sym_9();
+    void test_sym_10();
 
-    void test_contains_1() throw(libtest::test_exception);
-    void test_contains_2() throw(libtest::test_exception);
-    void test_contains_3() throw(libtest::test_exception);
-    void test_contains_4() throw(libtest::test_exception);
+    void test_contains_1();
+    void test_contains_2();
+    void test_contains_3();
+    void test_contains_4();
 
-    void test_locate_1() throw(libtest::test_exception);
-    void test_locate_2() throw(libtest::test_exception);
-    void test_locate_3() throw(libtest::test_exception);
-    void test_locate_4() throw(libtest::test_exception);
+    void test_locate_1();
+    void test_locate_2();
+    void test_locate_3();
+    void test_locate_4();
 
-    void test_perm_1() throw(libtest::test_exception);
-    void test_perm_2() throw(libtest::test_exception);
-    void test_perm_3() throw(libtest::test_exception);
-    void test_perm_4() throw(libtest::test_exception);
-    void test_perm_5() throw(libtest::test_exception);
-    void test_perm_6() throw(libtest::test_exception);
+    void test_perm_1();
+    void test_perm_2();
+    void test_perm_3();
+    void test_perm_4();
+    void test_perm_5();
+    void test_perm_6();
 
-    void test_exc_1() throw(libtest::test_exception);
+    void test_exc_1();
 
 };
 

--- a/tests/iface/bispace_test.C
+++ b/tests/iface/bispace_test.C
@@ -3,7 +3,7 @@
 
 namespace libtensor {
 
-void bispace_test::perform() throw(libtest::test_exception) {
+void bispace_test::perform() {
 
     test_1();
     test_2();
@@ -16,7 +16,7 @@ void bispace_test::perform() throw(libtest::test_exception) {
     test_9();
 }
 
-void bispace_test::test_1() throw(libtest::test_exception) {
+void bispace_test::test_1() {
 
     //
     //  Simple 1-d spaces
@@ -95,7 +95,7 @@ void bispace_test::test_1() throw(libtest::test_exception) {
     }
 }
 
-void bispace_test::test_2() throw(libtest::test_exception) {
+void bispace_test::test_2() {
 
     //
     //  Simple 2-d spaces
@@ -194,7 +194,7 @@ void bispace_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void bispace_test::test_3() throw(libtest::test_exception) {
+void bispace_test::test_3() {
 
     //
     //  2-d spaces with symmetry between 1-d
@@ -292,7 +292,7 @@ void bispace_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void bispace_test::test_4() throw(libtest::test_exception) {
+void bispace_test::test_4() {
 
     //
     //  4-d spaces with symmetry between symmetric 2-d
@@ -425,7 +425,7 @@ void bispace_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void bispace_test::test_5() throw(libtest::test_exception) {
+void bispace_test::test_5() {
 
     //
     //  4-d spaces with symmetry made of 1-d
@@ -564,7 +564,7 @@ void bispace_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void bispace_test::test_6() throw(libtest::test_exception) {
+void bispace_test::test_6() {
 
     //
     //  4-d spaces with symmetry made of 2-d,
@@ -717,7 +717,7 @@ void bispace_test::test_6() throw(libtest::test_exception) {
 }
 
 
-void bispace_test::test_7() throw(libtest::test_exception) {
+void bispace_test::test_7() {
 
     //
     //  4-d spaces with symmetry made of 1-d, reordered
@@ -856,7 +856,7 @@ void bispace_test::test_7() throw(libtest::test_exception) {
 }
 
 
-void bispace_test::test_8() throw(libtest::test_exception) {
+void bispace_test::test_8() {
 
     //
     //  5-d spaces with symmetry made of mixed dims, reordered
@@ -1011,7 +1011,7 @@ void bispace_test::test_8() throw(libtest::test_exception) {
 }
 
 
-void bispace_test::test_9() throw(libtest::test_exception) {
+void bispace_test::test_9() {
 
     //
     //  4-d spaces with symmetry between 1-d

--- a/tests/iface/bispace_test.h
+++ b/tests/iface/bispace_test.h
@@ -11,18 +11,18 @@ namespace libtensor {
  **/
 class bispace_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
+    void test_9();
 
 };
 

--- a/tests/iface/btensor_test.C
+++ b/tests/iface/btensor_test.C
@@ -4,7 +4,7 @@
 namespace libtensor {
 
 
-void btensor_test::perform() throw(libtest::test_exception) {
+void btensor_test::perform() {
 
     test_1();
     test_2();
@@ -14,7 +14,7 @@ using expr::label;
 
 /** \test Checks the dimensions of a new btensor
  **/
-void btensor_test::test_1() throw(libtest::test_exception) {
+void btensor_test::test_1() {
 
     static const char *testname = "btensor_test::test_1()";
 
@@ -44,7 +44,7 @@ void btensor_test::test_1() throw(libtest::test_exception) {
 
 /** \test Checks operator() with various letter labels
  **/
-void btensor_test::test_2() throw(libtest::test_exception) {
+void btensor_test::test_2() {
 
     static const char *testname = "btensor_test::test_2()";
 

--- a/tests/iface/btensor_test.h
+++ b/tests/iface/btensor_test.h
@@ -12,11 +12,11 @@ namespace libtensor {
 **/
 class btensor_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
 };
 
 

--- a/tests/iface/contract_test.C
+++ b/tests/iface/contract_test.C
@@ -16,7 +16,7 @@
 namespace libtensor {
 
 
-void contract_test::perform() throw(libtest::test_exception) {
+void contract_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/iface/contract_test.h
+++ b/tests/iface/contract_test.h
@@ -11,7 +11,7 @@ namespace libtensor {
 **/
 class contract_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_subexpr_labels_1();

--- a/tests/iface/diag_test.C
+++ b/tests/iface/diag_test.C
@@ -10,7 +10,7 @@
 namespace libtensor {
 
 
-void diag_test::perform() throw(libtest::test_exception) {
+void diag_test::perform() {
 
     allocator<double>::init();
 
@@ -35,7 +35,7 @@ void diag_test::perform() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_t_1() throw(libtest::test_exception) {
+void diag_test::test_t_1() {
 
     static const char testname[] = "diag_test::test_t_1()";
 
@@ -66,7 +66,7 @@ void diag_test::test_t_1() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_t_2() throw(libtest::test_exception) {
+void diag_test::test_t_2() {
 
     static const char testname[] = "diag_test::test_t_2()";
 
@@ -98,7 +98,7 @@ void diag_test::test_t_2() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_t_3() throw(libtest::test_exception) {
+void diag_test::test_t_3() {
 
     static const char testname[] = "diag_test::test_t_3()";
 
@@ -131,7 +131,7 @@ void diag_test::test_t_3() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_t_4() throw(libtest::test_exception) {
+void diag_test::test_t_4() {
 
     static const char testname[] = "diag_test::test_t_4()";
 
@@ -162,7 +162,7 @@ void diag_test::test_t_4() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_t_5() throw(libtest::test_exception) {
+void diag_test::test_t_5() {
 
     static const char testname[] = "diag_test::test_t_5()";
 
@@ -196,7 +196,7 @@ void diag_test::test_t_5() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_t_6() throw(libtest::test_exception) {
+void diag_test::test_t_6() {
 
     static const char testname[] = "diag_test::test_t_6()";
 
@@ -227,7 +227,7 @@ void diag_test::test_t_6() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_t_7() throw(libtest::test_exception) {
+void diag_test::test_t_7() {
 
     static const char testname[] = "diag_test::test_t_7()";
 
@@ -260,7 +260,7 @@ void diag_test::test_t_7() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_e_1() throw(libtest::test_exception) {
+void diag_test::test_e_1() {
 
     static const char testname[] = "diag_test::test_e_1()";
 
@@ -297,7 +297,7 @@ void diag_test::test_e_1() throw(libtest::test_exception) {
 }
 
 
-void diag_test::test_x_1() throw(libtest::test_exception) {
+void diag_test::test_x_1() {
 
     static const char testname[] = "diag_test::test_x_1()";
 

--- a/tests/iface/diag_test.h
+++ b/tests/iface/diag_test.h
@@ -11,18 +11,18 @@ namespace libtensor {
  **/
 class diag_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_t_1() throw(libtest::test_exception);
-    void test_t_2() throw(libtest::test_exception);
-    void test_t_3() throw(libtest::test_exception);
-    void test_t_4() throw(libtest::test_exception);
-    void test_t_5() throw(libtest::test_exception);
-    void test_t_6() throw(libtest::test_exception);
-    void test_t_7() throw(libtest::test_exception);
-    void test_e_1() throw(libtest::test_exception);
-    void test_x_1() throw(libtest::test_exception);
+    void test_t_1();
+    void test_t_2();
+    void test_t_3();
+    void test_t_4();
+    void test_t_5();
+    void test_t_6();
+    void test_t_7();
+    void test_e_1();
+    void test_x_1();
 
 };
 

--- a/tests/iface/direct_product_test.C
+++ b/tests/iface/direct_product_test.C
@@ -9,7 +9,7 @@
 namespace libtensor {
 
 
-void direct_product_test::perform() throw(libtest::test_exception) {
+void direct_product_test::perform() {
 
     allocator<double>::init();
 
@@ -33,7 +33,7 @@ void direct_product_test::perform() throw(libtest::test_exception) {
 
 
 #if 0
-void direct_product_test::test_label_1() throw(libtest::test_exception) {
+void direct_product_test::test_label_1() {
 
     static const char *testname = "direct_product_test::test_label_1()";
 
@@ -68,7 +68,7 @@ void direct_product_test::test_label_1() throw(libtest::test_exception) {
 #endif
 
 
-void direct_product_test::test_tt_1() throw(libtest::test_exception) {
+void direct_product_test::test_tt_1() {
 
     static const char *testname = "direct_product_test::test_tt_1()";
 
@@ -101,7 +101,7 @@ void direct_product_test::test_tt_1() throw(libtest::test_exception) {
 }
 
 
-void direct_product_test::test_tt_2() throw(libtest::test_exception) {
+void direct_product_test::test_tt_2() {
 
     static const char *testname = "direct_product_test::test_tt_2()";
 
@@ -135,7 +135,7 @@ void direct_product_test::test_tt_2() throw(libtest::test_exception) {
 }
 
 
-void direct_product_test::test_te_1() throw(libtest::test_exception) {
+void direct_product_test::test_te_1() {
 
     static const char *testname = "direct_product_test::test_te_1()";
 
@@ -173,7 +173,7 @@ void direct_product_test::test_te_1() throw(libtest::test_exception) {
 }
 
 
-void direct_product_test::test_et_1() throw(libtest::test_exception) {
+void direct_product_test::test_et_1() {
 
     static const char *testname = "direct_product_test::test_et_1()";
 
@@ -212,7 +212,7 @@ void direct_product_test::test_et_1() throw(libtest::test_exception) {
 }
 
 
-void direct_product_test::test_ee_1() throw(libtest::test_exception) {
+void direct_product_test::test_ee_1() {
 
     static const char *testname = "direct_product_test::test_ee_1()";
 
@@ -256,7 +256,7 @@ void direct_product_test::test_ee_1() throw(libtest::test_exception) {
 }
 
 
-void direct_product_test::test_ee_2() throw(libtest::test_exception) {
+void direct_product_test::test_ee_2() {
 
     static const char *testname = "direct_product_test::test_ee_2()";
 

--- a/tests/iface/direct_product_test.h
+++ b/tests/iface/direct_product_test.h
@@ -11,16 +11,16 @@ namespace libtensor {
 **/
 class direct_product_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_label_1() throw(libtest::test_exception);
-    void test_tt_1() throw(libtest::test_exception);
-    void test_tt_2() throw(libtest::test_exception);
-    void test_te_1() throw(libtest::test_exception);
-    void test_et_1() throw(libtest::test_exception);
-    void test_ee_1() throw(libtest::test_exception);
-    void test_ee_2() throw(libtest::test_exception);
+    void test_label_1();
+    void test_tt_1();
+    void test_tt_2();
+    void test_te_1();
+    void test_et_1();
+    void test_ee_1();
+    void test_ee_2();
 
 };
 

--- a/tests/iface/dirsum_test.C
+++ b/tests/iface/dirsum_test.C
@@ -11,7 +11,7 @@
 namespace libtensor {
 
 
-void dirsum_test::perform() throw(libtest::test_exception) {
+void dirsum_test::perform() {
 
     allocator<double>::init();
 
@@ -35,7 +35,7 @@ void dirsum_test::perform() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_tt_1() throw(libtest::test_exception) {
+void dirsum_test::test_tt_1() {
 
     static const char *testname = "dirsum_test::test_tt_1()";
 
@@ -66,7 +66,7 @@ void dirsum_test::test_tt_1() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_tt_2() throw(libtest::test_exception) {
+void dirsum_test::test_tt_2() {
 
     static const char *testname = "dirsum_test::test_tt_2()";
 
@@ -98,7 +98,7 @@ void dirsum_test::test_tt_2() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_tt_3() throw(libtest::test_exception) {
+void dirsum_test::test_tt_3() {
 
     static const char *testname = "dirsum_test::test_tt_3()";
 
@@ -133,7 +133,7 @@ void dirsum_test::test_tt_3() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_tt_4() throw(libtest::test_exception) {
+void dirsum_test::test_tt_4() {
 
     static const char *testname = "dirsum_test::test_tt_4()";
 
@@ -165,7 +165,7 @@ void dirsum_test::test_tt_4() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_tt_5() throw(libtest::test_exception) {
+void dirsum_test::test_tt_5() {
 
     static const char *testname = "dirsum_test::test_tt_5()";
 
@@ -200,7 +200,7 @@ void dirsum_test::test_tt_5() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_tt_6() throw(libtest::test_exception) {
+void dirsum_test::test_tt_6() {
 
     static const char *testname = "dirsum_test::test_tt_6()";
 
@@ -230,7 +230,7 @@ void dirsum_test::test_tt_6() throw(libtest::test_exception) {
 
 
 
-void dirsum_test::test_te_1() throw(libtest::test_exception) {
+void dirsum_test::test_te_1() {
 
     static const char *testname = "dirsum_test::test_te_1()";
 
@@ -273,7 +273,7 @@ void dirsum_test::test_te_1() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_et_1() throw(libtest::test_exception) {
+void dirsum_test::test_et_1() {
 
     static const char *testname = "dirsum_test::test_et_1()";
 
@@ -309,7 +309,7 @@ void dirsum_test::test_et_1() throw(libtest::test_exception) {
 }
 
 
-void dirsum_test::test_ee_1() throw(libtest::test_exception) {
+void dirsum_test::test_ee_1() {
 
     static const char *testname = "dirsum_test::test_ee_1()";
 

--- a/tests/iface/dirsum_test.h
+++ b/tests/iface/dirsum_test.h
@@ -11,18 +11,18 @@ namespace libtensor {
 **/
 class dirsum_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_tt_1() throw(libtest::test_exception);
-    void test_tt_2() throw(libtest::test_exception);
-    void test_tt_3() throw(libtest::test_exception);
-    void test_tt_4() throw(libtest::test_exception);
-    void test_tt_5() throw(libtest::test_exception);
-    void test_tt_6() throw(libtest::test_exception);
-    void test_te_1() throw(libtest::test_exception);
-    void test_et_1() throw(libtest::test_exception);
-    void test_ee_1() throw(libtest::test_exception);
+    void test_tt_1();
+    void test_tt_2();
+    void test_tt_3();
+    void test_tt_4();
+    void test_tt_5();
+    void test_tt_6();
+    void test_te_1();
+    void test_et_1();
+    void test_ee_1();
 
 };
 

--- a/tests/iface/dot_product_test.C
+++ b/tests/iface/dot_product_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void dot_product_test::perform() throw(libtest::test_exception) {
+void dot_product_test::perform() {
 
     allocator<double>::init();
 
@@ -34,7 +34,7 @@ void dot_product_test::perform() throw(libtest::test_exception) {
 }
 
 
-void dot_product_test::test_tt_ij_ij_1() throw(libtest::test_exception) {
+void dot_product_test::test_tt_ij_ij_1() {
 
     static const char *testname = "dot_product_test::test_tt_ij_ij_1()";
 
@@ -59,7 +59,7 @@ void dot_product_test::test_tt_ij_ij_1() throw(libtest::test_exception) {
 }
 
 
-void dot_product_test::test_tt_ij_ji_1() throw(libtest::test_exception) {
+void dot_product_test::test_tt_ij_ji_1() {
 
     static const char *testname = "dot_product_test::test_tt_ij_ji_1()";
 
@@ -85,7 +85,7 @@ void dot_product_test::test_tt_ij_ji_1() throw(libtest::test_exception) {
 }
 
 
-void dot_product_test::test_te_ij_ij_1() throw(libtest::test_exception) {
+void dot_product_test::test_te_ij_ij_1() {
 
     static const char *testname = "dot_product_test::test_te_ij_ij_1()";
 
@@ -113,7 +113,7 @@ void dot_product_test::test_te_ij_ij_1() throw(libtest::test_exception) {
 }
 
 
-void dot_product_test::test_te_ij_ji_1() throw(libtest::test_exception) {
+void dot_product_test::test_te_ij_ji_1() {
 
     static const char *testname = "dot_product_test::test_te_ij_ji_1()";
 
@@ -142,7 +142,7 @@ void dot_product_test::test_te_ij_ji_1() throw(libtest::test_exception) {
 }
 
 
-void dot_product_test::test_et_1() throw(libtest::test_exception) {
+void dot_product_test::test_et_1() {
 
     static const char *testname = "dot_product_test::test_et_1()";
 
@@ -177,7 +177,7 @@ void dot_product_test::test_et_1() throw(libtest::test_exception) {
 
 
 void dot_product_test::check_ref(const char *testname, double d, double d_ref)
-    throw(libtest::test_exception) {
+    {
 
     if(fabs(d - d_ref) > fabs(d_ref * 1e-14)) {
         std::ostringstream ss;

--- a/tests/iface/dot_product_test.h
+++ b/tests/iface/dot_product_test.h
@@ -11,17 +11,17 @@ namespace libtensor {
 **/
 class dot_product_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_tt_ij_ij_1() throw(libtest::test_exception);
-    void test_tt_ij_ji_1() throw(libtest::test_exception);
-    void test_te_ij_ij_1() throw(libtest::test_exception);
-    void test_te_ij_ji_1() throw(libtest::test_exception);
-    void test_et_1() throw(libtest::test_exception);
+    void test_tt_ij_ij_1();
+    void test_tt_ij_ji_1();
+    void test_te_ij_ij_1();
+    void test_te_ij_ji_1();
+    void test_et_1();
 
     void check_ref(const char *testname, double d, double d_ref)
-        throw(libtest::test_exception);
+       ;
 };
 
 } // namespace libtensor

--- a/tests/iface/eval_btensor_double_test.C
+++ b/tests/iface/eval_btensor_double_test.C
@@ -13,7 +13,7 @@ namespace libtensor {
 using namespace expr;
 
 
-void eval_btensor_double_test::perform() throw(libtest::test_exception) {
+void eval_btensor_double_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/iface/eval_btensor_double_test.h
+++ b/tests/iface/eval_btensor_double_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class eval_btensor_double_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_copy_1();

--- a/tests/iface/eval_register_test.C
+++ b/tests/iface/eval_register_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void eval_register_test::perform() throw(libtest::test_exception) {
+void eval_register_test::perform() {
 
     test_1();
 }

--- a/tests/iface/eval_register_test.h
+++ b/tests/iface/eval_register_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class eval_register_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/iface/ewmult_test.C
+++ b/tests/iface/ewmult_test.C
@@ -9,7 +9,7 @@
 namespace libtensor {
 
 
-void ewmult_test::perform() throw(libtest::test_exception) {
+void ewmult_test::perform() {
 
     allocator<double>::init();
 
@@ -31,7 +31,7 @@ void ewmult_test::perform() throw(libtest::test_exception) {
 }
 
 
-void ewmult_test::test_tt_1() throw(libtest::test_exception) {
+void ewmult_test::test_tt_1() {
 
     const char testname[] = "ewmult_test::test_tt_1()";
 
@@ -68,7 +68,7 @@ void ewmult_test::test_tt_1() throw(libtest::test_exception) {
 }
 
 
-void ewmult_test::test_tt_2() throw(libtest::test_exception) {
+void ewmult_test::test_tt_2() {
 
     const char testname[] = "ewmult_test::test_tt_2()";
 
@@ -106,7 +106,7 @@ void ewmult_test::test_tt_2() throw(libtest::test_exception) {
 }
 
 
-void ewmult_test::test_tt_3() throw(libtest::test_exception) {
+void ewmult_test::test_tt_3() {
 
     const char testname[] = "ewmult_test::test_tt_3()";
 
@@ -143,7 +143,7 @@ void ewmult_test::test_tt_3() throw(libtest::test_exception) {
 }
 
 
-void ewmult_test::test_te_1() throw(libtest::test_exception) {
+void ewmult_test::test_te_1() {
 
     const char testname[] = "ewmult_test::test_te_1()";
 
@@ -184,7 +184,7 @@ void ewmult_test::test_te_1() throw(libtest::test_exception) {
 }
 
 
-void ewmult_test::test_et_1() throw(libtest::test_exception) {
+void ewmult_test::test_et_1() {
 
     const char testname[] = "ewmult_test::test_et_1()";
 
@@ -225,7 +225,7 @@ void ewmult_test::test_et_1() throw(libtest::test_exception) {
 }
 
 
-void ewmult_test::test_ee_1() throw(libtest::test_exception) {
+void ewmult_test::test_ee_1() {
 
     const char testname[] = "ewmult_test::test_ee_1()";
 

--- a/tests/iface/ewmult_test.h
+++ b/tests/iface/ewmult_test.h
@@ -12,15 +12,15 @@ namespace libtensor {
  **/
 class ewmult_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_tt_1() throw(libtest::test_exception);
-    void test_tt_2() throw(libtest::test_exception);
-    void test_tt_3() throw(libtest::test_exception);
-    void test_te_1() throw(libtest::test_exception);
-    void test_et_1() throw(libtest::test_exception);
-    void test_ee_1() throw(libtest::test_exception);
+    void test_tt_1();
+    void test_tt_2();
+    void test_tt_3();
+    void test_te_1();
+    void test_et_1();
+    void test_ee_1();
 
 };
 

--- a/tests/iface/expr_tensor_test.C
+++ b/tests/iface/expr_tensor_test.C
@@ -19,7 +19,7 @@ void calculate_4(expr::expr_lhs<2, double> &t3,
 } // unnamed namespace
 
 
-void expr_tensor_test::perform() throw(libtest::test_exception) {
+void expr_tensor_test::perform() {
 
     test_1();
     test_2();

--- a/tests/iface/expr_tensor_test.h
+++ b/tests/iface/expr_tensor_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class expr_tensor_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1();

--- a/tests/iface/expr_test.C
+++ b/tests/iface/expr_test.C
@@ -15,7 +15,7 @@
 namespace libtensor {
 
 
-void expr_test::perform() throw(libtest::test_exception) {
+void expr_test::perform() {
 
     allocator<double>::init();
 
@@ -45,7 +45,7 @@ void expr_test::perform() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_1() throw(libtest::test_exception) {
+void expr_test::test_1() {
 
     static const char *testname = "expr_test::test_1()";
 
@@ -79,7 +79,7 @@ void expr_test::test_1() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_2() throw(libtest::test_exception) {
+void expr_test::test_2() {
 
     static const char *testname = "expr_test::test_2()";
 
@@ -126,7 +126,7 @@ void expr_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_3() throw(libtest::test_exception) {
+void expr_test::test_3() {
 
     static const char *testname = "expr_test::test_3()";
 
@@ -171,7 +171,7 @@ void expr_test::test_3() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_4() throw(libtest::test_exception) {
+void expr_test::test_4() {
 
     static const char *testname = "expr_test::test_4()";
 
@@ -225,7 +225,7 @@ void expr_test::test_4() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_5() throw(libtest::test_exception) {
+void expr_test::test_5() {
 
     static const char *testname = "expr_test::test_5()";
 
@@ -270,7 +270,7 @@ void expr_test::test_5() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_6() throw(libtest::test_exception) {
+void expr_test::test_6() {
 
     static const char *testname = "expr_test::test_6()";
 
@@ -396,7 +396,7 @@ void expr_test::test_6() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_7() throw(libtest::test_exception) {
+void expr_test::test_7() {
 
     static const char *testname = "expr_test::test_7()";
 
@@ -503,7 +503,7 @@ void expr_test::test_7() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_8() throw(libtest::test_exception) {
+void expr_test::test_8() {
 
     static const char *testname = "expr_test::test_8()";
 
@@ -599,7 +599,7 @@ void expr_test::test_8() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_9() throw(libtest::test_exception) {
+void expr_test::test_9() {
 
     static const char *testname = "expr_test::test_9()";
 
@@ -667,7 +667,7 @@ void expr_test::test_9() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_10() throw(libtest::test_exception) {
+void expr_test::test_10() {
 
     static const char *testname = "expr_test::test_10()";
 
@@ -735,7 +735,7 @@ void expr_test::test_10() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_11() throw(libtest::test_exception) {
+void expr_test::test_11() {
 
     static const char *testname = "expr_test::test_11()";
 
@@ -773,7 +773,7 @@ void expr_test::test_11() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_12() throw(libtest::test_exception) {
+void expr_test::test_12() {
 
     static const char *testname = "expr_test::test_12()";
 
@@ -805,7 +805,7 @@ void expr_test::test_12() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_13() throw(libtest::test_exception) {
+void expr_test::test_13() {
 
     static const char *testname = "expr_test::test_13()";
 
@@ -841,7 +841,7 @@ void expr_test::test_13() throw(libtest::test_exception) {
 }
 
 
-void expr_test::test_14() throw(libtest::test_exception) {
+void expr_test::test_14() {
 
     static const char *testname = "expr_test::test_14()";
 

--- a/tests/iface/expr_test.h
+++ b/tests/iface/expr_test.h
@@ -11,23 +11,23 @@ namespace libtensor {
  **/
 class expr_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
-    void test_9() throw(libtest::test_exception);
-    void test_10() throw(libtest::test_exception);
-    void test_11() throw(libtest::test_exception);
-    void test_12() throw(libtest::test_exception);
-    void test_13() throw(libtest::test_exception);
-    void test_14() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_7();
+    void test_8();
+    void test_9();
+    void test_10();
+    void test_11();
+    void test_12();
+    void test_13();
+    void test_14();
 
 };
 

--- a/tests/iface/letter_expr_test.C
+++ b/tests/iface/letter_expr_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void letter_expr_test::perform() throw(libtest::test_exception) {
+void letter_expr_test::perform() {
 
     test_contains();
     test_permutation();

--- a/tests/iface/letter_expr_test.h
+++ b/tests/iface/letter_expr_test.h
@@ -12,7 +12,7 @@ namespace libtensor {
 **/
 class letter_expr_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_contains();

--- a/tests/iface/letter_test.C
+++ b/tests/iface/letter_test.C
@@ -3,7 +3,7 @@
 
 namespace libtensor {
 
-void letter_test::perform() throw(libtest::test_exception) {
+void letter_test::perform() {
     letter i, j, k, l;
     letter &i_ref(i);
 

--- a/tests/iface/letter_test.h
+++ b/tests/iface/letter_test.h
@@ -11,7 +11,7 @@ namespace libtensor {
 **/
 class letter_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 };
 

--- a/tests/iface/mult_test.C
+++ b/tests/iface/mult_test.C
@@ -11,7 +11,7 @@
 namespace libtensor {
 
 
-void mult_test::perform() throw(libtest::test_exception) {
+void mult_test::perform() {
 
     allocator<double>::init();
 
@@ -43,7 +43,7 @@ void mult_test::perform() throw(libtest::test_exception) {
 }
 
 
-void mult_test::test_tt_1a() throw(libtest::test_exception) {
+void mult_test::test_tt_1a() {
 
     static const char *testname = "mult_test::test_tt_1a()";
 
@@ -71,7 +71,7 @@ void mult_test::test_tt_1a() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_tt_1b() throw(libtest::test_exception) {
+void mult_test::test_tt_1b() {
 
     static const char *testname = "mult_test::test_tt_1b()";
 
@@ -100,7 +100,7 @@ void mult_test::test_tt_1b() throw(libtest::test_exception) {
 }
 
 
-void mult_test::test_tt_2() throw(libtest::test_exception) {
+void mult_test::test_tt_2() {
 
     static const char *testname = "mult_test::test_tt_2()";
 
@@ -132,7 +132,7 @@ void mult_test::test_tt_2() throw(libtest::test_exception) {
 }
 
 
-void mult_test::test_tt_3() throw(libtest::test_exception) {
+void mult_test::test_tt_3() {
 
     static const char *testname = "mult_test::test_tt_3()";
 
@@ -164,7 +164,7 @@ void mult_test::test_tt_3() throw(libtest::test_exception) {
 }
 
 
-void mult_test::test_tt_4() throw(libtest::test_exception) {
+void mult_test::test_tt_4() {
 
     static const char *testname = "mult_test::test_tt_4()";
 
@@ -197,7 +197,7 @@ void mult_test::test_tt_4() throw(libtest::test_exception) {
 }
 
 
-void mult_test::test_tt_5() throw(libtest::test_exception) {
+void mult_test::test_tt_5() {
 
     static const char *testname = "mult_test::test_tt_5()";
 
@@ -225,7 +225,7 @@ void mult_test::test_tt_5() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_tt_6a() throw(libtest::test_exception) {
+void mult_test::test_tt_6a() {
 
     static const char *testname = "mult_test::test_tt_6a()";
 
@@ -253,7 +253,7 @@ void mult_test::test_tt_6a() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_tt_6b() throw(libtest::test_exception) {
+void mult_test::test_tt_6b() {
 
     static const char *testname = "mult_test::test_tt_6b()";
 
@@ -281,7 +281,7 @@ void mult_test::test_tt_6b() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_te_1() throw(libtest::test_exception) {
+void mult_test::test_te_1() {
 
     static const char *testname = "mult_test::test_te_1()";
 
@@ -323,7 +323,7 @@ void mult_test::test_te_1() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_te_2() throw(libtest::test_exception) {
+void mult_test::test_te_2() {
 
     static const char *testname = "mult_test::test_te_2()";
 
@@ -361,7 +361,7 @@ void mult_test::test_te_2() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_te_3() throw(libtest::test_exception) {
+void mult_test::test_te_3() {
 
     static const char *testname = "mult_test::test_te_3()";
 
@@ -400,7 +400,7 @@ void mult_test::test_te_3() throw(libtest::test_exception) {
 }
 
 
-void mult_test::test_et_1() throw(libtest::test_exception) {
+void mult_test::test_et_1() {
 
     static const char *testname = "mult_test::test_et_1()";
 
@@ -437,7 +437,7 @@ void mult_test::test_et_1() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_et_2() throw(libtest::test_exception) {
+void mult_test::test_et_2() {
 
     static const char *testname = "mult_test::test_et_2()";
 
@@ -475,7 +475,7 @@ void mult_test::test_et_2() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_et_3() throw(libtest::test_exception) {
+void mult_test::test_et_3() {
 
     static const char *testname = "mult_test::test_et_3()";
 
@@ -514,7 +514,7 @@ void mult_test::test_et_3() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_ee_1a() throw(libtest::test_exception) {
+void mult_test::test_ee_1a() {
 
     static const char *testname = "mult_test::test_ee_1a()";
 
@@ -554,7 +554,7 @@ void mult_test::test_ee_1a() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_ee_1b() throw(libtest::test_exception) {
+void mult_test::test_ee_1b() {
 
     static const char *testname = "mult_test::test_ee_1b()";
 
@@ -594,7 +594,7 @@ void mult_test::test_ee_1b() throw(libtest::test_exception) {
     }
 }
 
-void mult_test::test_ee_2() throw(libtest::test_exception) {
+void mult_test::test_ee_2() {
 
     static const char *testname = "mult_test::test_ee_2()";
 

--- a/tests/iface/mult_test.h
+++ b/tests/iface/mult_test.h
@@ -11,26 +11,26 @@ namespace libtensor {
 **/
 class mult_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_tt_1a() throw(libtest::test_exception);
-    void test_tt_1b() throw(libtest::test_exception);
-    void test_tt_2() throw(libtest::test_exception);
-    void test_tt_3() throw(libtest::test_exception);
-    void test_tt_4() throw(libtest::test_exception);
-    void test_tt_5() throw(libtest::test_exception);
-    void test_tt_6a() throw(libtest::test_exception);
-    void test_tt_6b() throw(libtest::test_exception);
-    void test_te_1() throw(libtest::test_exception);
-    void test_te_2() throw(libtest::test_exception);
-    void test_te_3() throw(libtest::test_exception);
-    void test_et_1() throw(libtest::test_exception);
-    void test_et_2() throw(libtest::test_exception);
-    void test_et_3() throw(libtest::test_exception);
-    void test_ee_1a() throw(libtest::test_exception);
-    void test_ee_1b() throw(libtest::test_exception);
-    void test_ee_2() throw(libtest::test_exception);
+    void test_tt_1a();
+    void test_tt_1b();
+    void test_tt_2();
+    void test_tt_3();
+    void test_tt_4();
+    void test_tt_5();
+    void test_tt_6a();
+    void test_tt_6b();
+    void test_te_1();
+    void test_te_2();
+    void test_te_3();
+    void test_et_1();
+    void test_et_2();
+    void test_et_3();
+    void test_ee_1a();
+    void test_ee_1b();
+    void test_ee_2();
 
 };
 

--- a/tests/iface/set_test.C
+++ b/tests/iface/set_test.C
@@ -13,7 +13,7 @@
 namespace libtensor {
 
 
-void set_test::perform() throw(libtest::test_exception) {
+void set_test::perform() {
 
     allocator<double>::init();
 

--- a/tests/iface/set_test.h
+++ b/tests/iface/set_test.h
@@ -11,7 +11,7 @@ namespace libtensor {
  **/
 class set_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_s_1(double d);

--- a/tests/iface/symm_test.C
+++ b/tests/iface/symm_test.C
@@ -17,7 +17,7 @@
 namespace libtensor {
 
 
-void symm_test::perform() throw(libtest::test_exception) {
+void symm_test::perform() {
 
     allocator<double>::init();
 
@@ -58,7 +58,7 @@ void symm_test::perform() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_symm2_contr_tt_1() throw(libtest::test_exception) {
+void symm_test::test_symm2_contr_tt_1() {
 
     const char *testname = "symm_test::test_symm2_contr_tt_1()";
 
@@ -97,7 +97,7 @@ void symm_test::test_symm2_contr_tt_1() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_symm2_contr_tt_2() throw(libtest::test_exception) {
+void symm_test::test_symm2_contr_tt_2() {
 
     const char testname[] = "symm_test::test_symm2_contr_tt_2()";
 
@@ -138,7 +138,7 @@ void symm_test::test_symm2_contr_tt_2() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_symm2_contr_ee_1() throw(libtest::test_exception) {
+void symm_test::test_symm2_contr_ee_1() {
 
     const char *testname = "symm_test::test_symm2_contr_ee_1()";
 
@@ -194,7 +194,7 @@ void symm_test::test_symm2_contr_ee_1() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_tt_1() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_tt_1() {
 
     const char *testname = "asym_contract_test::test_asymm2_contr_tt_1()";
 
@@ -233,7 +233,7 @@ void symm_test::test_asymm2_contr_tt_1() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_tt_2() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_tt_2() {
 
     const char *testname = "symm_test::test_asymm2_contr_tt_2()";
 
@@ -277,7 +277,7 @@ void symm_test::test_asymm2_contr_tt_2() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_tt_3() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_tt_3() {
 
     const char *testname = "symm_test::test_asymm2_contr_tt_3()";
 
@@ -315,7 +315,7 @@ void symm_test::test_asymm2_contr_tt_3() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_tt_4() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_tt_4() {
 
     const char *testname = "symm_test::test_asymm2_contr_tt_4()";
 
@@ -354,7 +354,7 @@ void symm_test::test_asymm2_contr_tt_4() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_tt_5() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_tt_5() {
 
     const char *testname = "symm_test::test_asymm2_contr_tt_5()";
 
@@ -406,7 +406,7 @@ void symm_test::test_asymm2_contr_tt_5() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_tt_6() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_tt_6() {
 
     const char *testname = "symm_test::test_asymm2_contr_tt_6()";
 
@@ -494,7 +494,7 @@ void symm_test::test_asymm2_contr_tt_6() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_et_1() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_et_1() {
 
     const char *testname = "symm_test::test_asymm2_contr_et_1()";
 
@@ -539,7 +539,7 @@ void symm_test::test_asymm2_contr_et_1() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm2_contr_ee_1() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_ee_1() {
 
     const char *testname = "symm_test::test_asymm2_contr_ee_1()";
 
@@ -594,7 +594,7 @@ void symm_test::test_asymm2_contr_ee_1() throw(libtest::test_exception) {
     }
 }
 
-void symm_test::test_asymm2_contr_ee_2() throw(libtest::test_exception) {
+void symm_test::test_asymm2_contr_ee_2() {
 
     const char *testname = "symm_test::test_asymm2_contr_ee_2()";
 
@@ -643,7 +643,7 @@ void symm_test::test_asymm2_contr_ee_2() throw(libtest::test_exception) {
 /** \test Tests the symmetrization over two pairs of indexes P+(ij)P+(ab)
         in a %tensor
  **/
-void symm_test::test_symm22_t_1() throw(libtest::test_exception) {
+void symm_test::test_symm22_t_1() {
 
     const char *testname = "symm_test::test_symm22_t_1()";
 
@@ -680,7 +680,7 @@ void symm_test::test_symm22_t_1() throw(libtest::test_exception) {
 /** \test Tests the anti-symmetrization over two pairs of indexes
         P-(ij)P-(ab) in a %tensor
  **/
-void symm_test::test_asymm22_t_1() throw(libtest::test_exception) {
+void symm_test::test_asymm22_t_1() {
 
     const char *testname = "symm_test::test_asymm22_t_1()";
 
@@ -717,7 +717,7 @@ void symm_test::test_asymm22_t_1() throw(libtest::test_exception) {
 /** \test Tests the symmetrization over two pairs of indexes P+(i|jk)
         in a %tensor
  **/
-void symm_test::test_symm22_t_2() throw(libtest::test_exception) {
+void symm_test::test_symm22_t_2() {
 
     const char *testname = "symm_test::test_symm22_t_2()";
 
@@ -753,7 +753,7 @@ void symm_test::test_symm22_t_2() throw(libtest::test_exception) {
 /** \test Tests the anti-symmetrization over two pairs of indexes P-(i|jk)
         in a %tensor
  **/
-void symm_test::test_asymm22_t_2() throw(libtest::test_exception) {
+void symm_test::test_asymm22_t_2() {
 
     const char *testname = "symm_test::test_asymm22_t_2()";
 
@@ -789,7 +789,7 @@ void symm_test::test_asymm22_t_2() throw(libtest::test_exception) {
 /** \test Tests the symmetrization over two pairs of indexes P+(ij)P+(ab)
         in an expression
  **/
-void symm_test::test_symm22_e_1() throw(libtest::test_exception) {
+void symm_test::test_symm22_e_1() {
 
     const char *testname = "symm_test::test_symm22_e_1()";
 
@@ -830,7 +830,7 @@ void symm_test::test_symm22_e_1() throw(libtest::test_exception) {
 /** \test Tests the anti-symmetrization over two pairs of indexes
         P-(ij)P-(ab) in an expression
  **/
-void symm_test::test_asymm22_e_1() throw(libtest::test_exception) {
+void symm_test::test_asymm22_e_1() {
 
     const char *testname = "symm_test::test_asymm22_e_1()";
 
@@ -871,7 +871,7 @@ void symm_test::test_asymm22_e_1() throw(libtest::test_exception) {
 /** \test Tests the symmetrization over two pairs of indexes P+(i|jk)
         in an expression
  **/
-void symm_test::test_symm22_e_2() throw(libtest::test_exception) {
+void symm_test::test_symm22_e_2() {
 
     const char *testname = "symm_test::test_symm22_e_2()";
 
@@ -912,7 +912,7 @@ void symm_test::test_symm22_e_2() throw(libtest::test_exception) {
 /** \test Tests the anti-symmetrization over two pairs of indexes P-(i|jk)
         in an expression
  **/
-void symm_test::test_asymm22_e_2() throw(libtest::test_exception) {
+void symm_test::test_asymm22_e_2() {
 
     const char *testname = "symm_test::test_asymm22_e_2()";
 
@@ -952,7 +952,7 @@ void symm_test::test_asymm22_e_2() throw(libtest::test_exception) {
 
 /** \test Tests the symmetrization over three indexes in a %tensor
  **/
-void symm_test::test_symm3_t_1() throw(libtest::test_exception) {
+void symm_test::test_symm3_t_1() {
 
     const char *testname = "symm_test::test_symm3_t_1()";
 
@@ -993,7 +993,7 @@ void symm_test::test_symm3_t_1() throw(libtest::test_exception) {
 }
 
 
-void symm_test::test_asymm3_e_1() throw(libtest::test_exception) {
+void symm_test::test_asymm3_e_1() {
 
     const char *testname = "symm_test::test_asymm3_e_1()";
 

--- a/tests/iface/symm_test.h
+++ b/tests/iface/symm_test.h
@@ -11,34 +11,34 @@ namespace libtensor {
 **/
 class symm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_symm2_contr_tt_1() throw(libtest::test_exception);
-    void test_symm2_contr_tt_2() throw(libtest::test_exception);
-    void test_symm2_contr_ee_1() throw(libtest::test_exception);
-    void test_asymm2_contr_tt_1() throw(libtest::test_exception);
-    void test_asymm2_contr_tt_2() throw(libtest::test_exception);
-    void test_asymm2_contr_tt_3() throw(libtest::test_exception);
-    void test_asymm2_contr_tt_4() throw(libtest::test_exception);
-    void test_asymm2_contr_tt_5() throw(libtest::test_exception);
-    void test_asymm2_contr_tt_6() throw(libtest::test_exception);
-    void test_asymm2_contr_et_1() throw(libtest::test_exception);
-    void test_asymm2_contr_ee_1() throw(libtest::test_exception);
-    void test_asymm2_contr_ee_2() throw(libtest::test_exception);
+    void test_symm2_contr_tt_1();
+    void test_symm2_contr_tt_2();
+    void test_symm2_contr_ee_1();
+    void test_asymm2_contr_tt_1();
+    void test_asymm2_contr_tt_2();
+    void test_asymm2_contr_tt_3();
+    void test_asymm2_contr_tt_4();
+    void test_asymm2_contr_tt_5();
+    void test_asymm2_contr_tt_6();
+    void test_asymm2_contr_et_1();
+    void test_asymm2_contr_ee_1();
+    void test_asymm2_contr_ee_2();
 
-    void test_symm22_t_1() throw(libtest::test_exception);
-    void test_asymm22_t_1() throw(libtest::test_exception);
-    void test_symm22_t_2() throw(libtest::test_exception);
-    void test_asymm22_t_2() throw(libtest::test_exception);
+    void test_symm22_t_1();
+    void test_asymm22_t_1();
+    void test_symm22_t_2();
+    void test_asymm22_t_2();
 
-    void test_symm22_e_1() throw(libtest::test_exception);
-    void test_asymm22_e_1() throw(libtest::test_exception);
-    void test_symm22_e_2() throw(libtest::test_exception);
-    void test_asymm22_e_2() throw(libtest::test_exception);
+    void test_symm22_e_1();
+    void test_asymm22_e_1();
+    void test_symm22_e_2();
+    void test_asymm22_e_2();
 
-    void test_symm3_t_1() throw(libtest::test_exception);
-    void test_asymm3_e_1() throw(libtest::test_exception);
+    void test_symm3_t_1();
+    void test_asymm3_e_1();
 };
 
 } // namespace libtensor

--- a/tests/iface/trace_test.C
+++ b/tests/iface/trace_test.C
@@ -11,7 +11,7 @@
 namespace libtensor {
 
 
-void trace_test::perform() throw(libtest::test_exception) {
+void trace_test::perform() {
 
     allocator<double>::init();
 
@@ -200,7 +200,7 @@ void trace_test::test_e_3() {
 
 
 void trace_test::check_ref(const char *testname, double d, double d_ref)
-    throw(libtest::test_exception) {
+    {
 
     if(fabs(d - d_ref) > fabs(d_ref * 1e-14)) {
         std::ostringstream ss;

--- a/tests/iface/trace_test.h
+++ b/tests/iface/trace_test.h
@@ -11,7 +11,7 @@ namespace libtensor {
  **/
 class trace_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_t_1();
@@ -22,7 +22,7 @@ private:
     void test_e_3();
 
     void check_ref(const char *testname, double d, double d_ref)
-        throw(libtest::test_exception);
+       ;
 };
 
 } // namespace libtensor

--- a/tests/symmetry/adjacency_list_test.h
+++ b/tests/symmetry/adjacency_list_test.h
@@ -11,13 +11,13 @@ namespace libtensor {
  **/
 class adjacency_list_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/block_labeling_test.h
+++ b/tests/symmetry/block_labeling_test.h
@@ -11,15 +11,15 @@ namespace libtensor {
  **/
 class block_labeling_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_basic_1() throw(libtest::test_exception);
-    void test_basic_2() throw(libtest::test_exception);
-    void test_copy_1() throw(libtest::test_exception);
-    void test_permute_1() throw(libtest::test_exception);
-    void test_transfer_1() throw(libtest::test_exception);
-    void test_transfer_2() throw(libtest::test_exception);
+    void test_basic_1();
+    void test_basic_2();
+    void test_copy_1();
+    void test_permute_1();
+    void test_transfer_1();
+    void test_transfer_2();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/combine_label_test.h
+++ b/tests/symmetry/combine_label_test.h
@@ -12,13 +12,13 @@ namespace libtensor {
  **/
 class combine_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/combine_part_test.h
+++ b/tests/symmetry/combine_part_test.h
@@ -12,15 +12,15 @@ namespace libtensor {
  **/
 class combine_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2(bool symm) throw(libtest::test_exception);
-    void test_3(bool symm1, bool symm2) throw(libtest::test_exception);
+    void test_1();
+    void test_2(bool symm);
+    void test_3(bool symm1, bool symm2);
     void test_4a(bool symm1, bool symm2,
-            bool forbidden) throw(libtest::test_exception);
-    void test_4b(bool symm1, bool symm2) throw(libtest::test_exception);
+            bool forbidden);
+    void test_4b(bool symm1, bool symm2);
 
 };
 

--- a/tests/symmetry/er_merge_test.h
+++ b/tests/symmetry/er_merge_test.h
@@ -11,13 +11,13 @@ namespace libtensor {
  **/
 class er_merge_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(const std::string &id) throw(libtest::test_exception);
-    void test_2(const std::string &id) throw(libtest::test_exception);
-    void test_3(const std::string &id) throw(libtest::test_exception);
-    void test_4(const std::string &id) throw(libtest::test_exception);
+    void test_1(const std::string &id);
+    void test_2(const std::string &id);
+    void test_3(const std::string &id);
+    void test_4(const std::string &id);
 };
 
 } // namespace libtensor

--- a/tests/symmetry/er_optimize_test.h
+++ b/tests/symmetry/er_optimize_test.h
@@ -11,12 +11,12 @@ namespace libtensor {
  **/
 class er_optimize_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(const std::string &id) throw(libtest::test_exception);
-    void test_2(const std::string &id) throw(libtest::test_exception);
-    void test_3(const std::string &id) throw(libtest::test_exception);
+    void test_1(const std::string &id);
+    void test_2(const std::string &id);
+    void test_3(const std::string &id);
 };
 
 } // namespace libtensor

--- a/tests/symmetry/er_reduce_test.C
+++ b/tests/symmetry/er_reduce_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void er_reduce_test::perform() throw(libtest::test_exception) {
+void er_reduce_test::perform() {
 
     std::string s6 = "S6", c2v = "C2v";
     setup_pg_table(s6);
@@ -48,7 +48,7 @@ void er_reduce_test::perform() throw(libtest::test_exception) {
 /** \brief Reduce of two dimensions in one step (complete dim)
  **/
 void er_reduce_test::test_1(
-        const std::string &id) throw(libtest::test_exception) {
+        const std::string &id) {
 
     static const char *testname = "er_reduce_test::test_1()";
 
@@ -129,7 +129,7 @@ void er_reduce_test::test_1(
 /** \brief Reduction of four dimensions in two steps (complete dim)
  **/
 void er_reduce_test::test_2(
-        const std::string &id) throw(libtest::test_exception) {
+        const std::string &id) {
 
 
     static const char *testname = "er_reduce_test::test_2()";
@@ -216,7 +216,7 @@ void er_reduce_test::test_2(
 /** \brief Reduction of six dimensions in three steps (complete dims)
  **/
 void er_reduce_test::test_3(
-        const std::string &id) throw(libtest::test_exception) {
+        const std::string &id) {
 
 
     static const char *testname = "er_reduce_test::test_3()";
@@ -293,7 +293,7 @@ void er_reduce_test::test_3(
 /** \brief Reduction of four dimensions in two steps (one complete dims)
  **/
 void er_reduce_test::test_4(
-        const std::string &id) throw(libtest::test_exception) {
+        const std::string &id) {
 
 
     static const char *testname = "er_reduce_test::test_4()";
@@ -412,7 +412,7 @@ void er_reduce_test::test_4(
 /** \brief Reduction of two dimensions in one step (complete dims)
  **/
 void er_reduce_test::test_5(
-        const std::string &id) throw(libtest::test_exception) {
+        const std::string &id) {
 
     static const char *testname = "er_reduce_test::test_5()";
 
@@ -494,7 +494,7 @@ void er_reduce_test::test_5(
 /** \brief Reduction of four dimensions in two steps (non-complete dims)
  **/
 void er_reduce_test::test_6(
-        const std::string &id) throw(libtest::test_exception) {
+        const std::string &id) {
 
 
     static const char *testname = "er_reduce_test::test_6()";
@@ -600,7 +600,7 @@ void er_reduce_test::test_6(
 /** \brief Reduction of two dimensions in one steps
  **/
 void er_reduce_test::test_7(
-        const std::string &id) throw(libtest::test_exception) {
+        const std::string &id) {
 
 
     static const char *testname = "er_reduce_test::test_7()";

--- a/tests/symmetry/er_reduce_test.h
+++ b/tests/symmetry/er_reduce_test.h
@@ -11,16 +11,16 @@ namespace libtensor {
  **/
 class er_reduce_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(const std::string &id) throw(libtest::test_exception);
-    void test_2(const std::string &id) throw(libtest::test_exception);
-    void test_3(const std::string &id) throw(libtest::test_exception);
-    void test_4(const std::string &id) throw(libtest::test_exception);
-    void test_5(const std::string &id) throw(libtest::test_exception);
-    void test_6(const std::string &id) throw(libtest::test_exception);
-    void test_7(const std::string &id) throw(libtest::test_exception);
+    void test_1(const std::string &id);
+    void test_2(const std::string &id);
+    void test_3(const std::string &id);
+    void test_4(const std::string &id);
+    void test_5(const std::string &id);
+    void test_6(const std::string &id);
+    void test_7(const std::string &id);
 };
 
 } // namespace libtensor

--- a/tests/symmetry/eval_sequence_list_test.C
+++ b/tests/symmetry/eval_sequence_list_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void eval_sequence_list_test::perform() throw(libtest::test_exception) {
+void eval_sequence_list_test::perform() {
 
     test_1();
 }
@@ -13,7 +13,7 @@ void eval_sequence_list_test::perform() throw(libtest::test_exception) {
 
 /** \test Add sequences to the list of sequences + try accessing them.
  **/
-void eval_sequence_list_test::test_1() throw(libtest::test_exception) {
+void eval_sequence_list_test::test_1() {
 
     static const char *testname = "eval_sequence_list_test::test_1()";
 

--- a/tests/symmetry/eval_sequence_list_test.h
+++ b/tests/symmetry/eval_sequence_list_test.h
@@ -11,10 +11,10 @@ namespace libtensor {
  **/
 class eval_sequence_list_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
+    void test_1();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/evaluation_rule_test.C
+++ b/tests/symmetry/evaluation_rule_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void evaluation_rule_test::perform() throw(libtest::test_exception) {
+void evaluation_rule_test::perform() {
 
     test_1();
     test_copy_1();
@@ -14,7 +14,7 @@ void evaluation_rule_test::perform() throw(libtest::test_exception) {
 
 /** \test Create product(s), traverse them, clear them
  **/
-void evaluation_rule_test::test_1() throw(libtest::test_exception) {
+void evaluation_rule_test::test_1() {
 
     static const char *testname = "evaluation_rule_test::test_1()";
 
@@ -74,7 +74,7 @@ void evaluation_rule_test::test_1() throw(libtest::test_exception) {
 
 /** \test Copy constructor, operator=
  **/
-void evaluation_rule_test::test_copy_1() throw(libtest::test_exception) {
+void evaluation_rule_test::test_copy_1() {
 
     static const char *testname = "evaluation_rule_test::test_copy_1()";
 

--- a/tests/symmetry/evaluation_rule_test.h
+++ b/tests/symmetry/evaluation_rule_test.h
@@ -11,11 +11,11 @@ namespace libtensor {
  **/
 class evaluation_rule_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_copy_1() throw(libtest::test_exception);
+    void test_1();
+    void test_copy_1();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/permutation_group_test.C
+++ b/tests/symmetry/permutation_group_test.C
@@ -12,7 +12,7 @@
 namespace libtensor {
 
 
-void permutation_group_test::perform() throw(libtest::test_exception) {
+void permutation_group_test::perform() {
 
     test_1();
     test_2a();
@@ -53,7 +53,7 @@ void permutation_group_test::perform() throw(libtest::test_exception) {
 
 /** \test Tests the C1 group in a 4-space
  **/
-void permutation_group_test::test_1() throw(libtest::test_exception) {
+void permutation_group_test::test_1() {
 
     static const char *testname = "permutation_group_test::test_1()";
 
@@ -79,7 +79,7 @@ void permutation_group_test::test_1() throw(libtest::test_exception) {
 
 /** \test Tests the S2(+) group in a 2-space
  **/
-void permutation_group_test::test_2a() throw(libtest::test_exception) {
+void permutation_group_test::test_2a() {
 
     static const char *testname = "permutation_group_test::test_2a()";
 
@@ -110,7 +110,7 @@ void permutation_group_test::test_2a() throw(libtest::test_exception) {
 
 /** \test Tests the S2(-) group in a 2-space
  **/
-void permutation_group_test::test_2b() throw(libtest::test_exception) {
+void permutation_group_test::test_2b() {
 
     static const char *testname = "permutation_group_test::test_2b()";
 
@@ -142,7 +142,7 @@ void permutation_group_test::test_2b() throw(libtest::test_exception) {
 /** \test Tests the S3(+) group in a 3-space. The group is created using
         [012->120] and [012->102].
  **/
-void permutation_group_test::test_3() throw(libtest::test_exception) {
+void permutation_group_test::test_3() {
 
     static const char *testname = "permutation_group_test::test_3()";
 
@@ -181,7 +181,7 @@ void permutation_group_test::test_3() throw(libtest::test_exception) {
 
 /** \test Tests the A4(+) group in a 4-space
  **/
-void permutation_group_test::test_4() throw(libtest::test_exception) {
+void permutation_group_test::test_4() {
 
     static const char *testname = "permutation_group_test::test_4()";
 
@@ -233,7 +233,7 @@ void permutation_group_test::test_4() throw(libtest::test_exception) {
 
 /** \test Tests the S2(+)*S2(+) group in a 4-space
  **/
-void permutation_group_test::test_5a() throw(libtest::test_exception) {
+void permutation_group_test::test_5a() {
 
     static const char *testname = "permutation_group_test::test_5a()";
 
@@ -267,7 +267,7 @@ void permutation_group_test::test_5a() throw(libtest::test_exception) {
 
 /** \test Tests the S2(-)*S2(-) group in a 4-space
  **/
-void permutation_group_test::test_5b() throw(libtest::test_exception) {
+void permutation_group_test::test_5b() {
 
     static const char *testname = "permutation_group_test::test_5b()";
 
@@ -301,7 +301,7 @@ void permutation_group_test::test_5b() throw(libtest::test_exception) {
 
 /** \test Tests the S4(+) group in a 4-space
  **/
-void permutation_group_test::test_6a() throw(libtest::test_exception) {
+void permutation_group_test::test_6a() {
 
     static const char *testname = "permutation_group_test::test_6a()";
 
@@ -333,7 +333,7 @@ void permutation_group_test::test_6a() throw(libtest::test_exception) {
 
 /** \test Tests the S4(-) group in a 4-space
  **/
-void permutation_group_test::test_6b() throw(libtest::test_exception) {
+void permutation_group_test::test_6b() {
 
     static const char *testname = "permutation_group_test::test_6b()";
 
@@ -371,7 +371,7 @@ void permutation_group_test::test_6b() throw(libtest::test_exception) {
 
 /** \test Tests a symmetric perm group in a 4-space
  **/
-void permutation_group_test::test_7() throw(libtest::test_exception) {
+void permutation_group_test::test_7() {
 
     static const char *testname = "permutation_group_test::test_7()";
 
@@ -419,7 +419,7 @@ void permutation_group_test::test_7() throw(libtest::test_exception) {
 
 /** \test Tests a symmetric perm group in a 6-space
  **/
-void permutation_group_test::test_8() throw(libtest::test_exception) {
+void permutation_group_test::test_8() {
 
     static const char *testname = "permutation_group_test::test_8()";
 
@@ -1151,7 +1151,7 @@ throw(libtest::test_exception) {
 
 /** \test Test the identity %permutation on S2(+)*S2(+).
  **/
-void permutation_group_test::test_permute_1() throw(libtest::test_exception) {
+void permutation_group_test::test_permute_1() {
 
     static const char *testname =
             "permutation_group_test::test_permute_1()";
@@ -1191,7 +1191,7 @@ void permutation_group_test::test_permute_1() throw(libtest::test_exception) {
 
 /** \test Test a non-identity %permutation on S2(+)*S2(+).
  **/
-void permutation_group_test::test_permute_2() throw(libtest::test_exception) {
+void permutation_group_test::test_permute_2() {
 
     static const char *testname =
             "permutation_group_test::test_permute_2()";
@@ -1234,7 +1234,7 @@ void permutation_group_test::test_permute_2() throw(libtest::test_exception) {
 
 /** \test Test a non-identity %permutation on S3(+)*C1.
  **/
-void permutation_group_test::test_permute_3() throw(libtest::test_exception) {
+void permutation_group_test::test_permute_3() {
 
     static const char *testname =
             "permutation_group_test::test_permute_3()";
@@ -1332,7 +1332,7 @@ template<size_t N, typename T>
 void permutation_group_test::verify_members(const char *testname,
         const permutation_group<N, T> &grp, const scalar_transf<T> &tr,
         const std::list< std::pair<permutation<N>, scalar_transf<T> > > &allowed)
-    throw(libtest::test_exception) {
+    {
 
     typedef std::pair<permutation<N>, scalar_transf<T> > gen_perm_t;
     typedef std::list<gen_perm_t> perm_list_t;

--- a/tests/symmetry/permutation_group_test.C
+++ b/tests/symmetry/permutation_group_test.C
@@ -463,8 +463,7 @@ void permutation_group_test::test_8() {
 /** \test Tests the projection of the S4(+) group in a 4-space onto
         a 2-space, S2(+)
  **/
-void permutation_group_test::test_project_down_1()
-throw(libtest::test_exception) {
+void permutation_group_test::test_project_down_1() {
 
     static const char *testname =
             "permutation_group_test::test_project_down_1()";
@@ -508,8 +507,7 @@ throw(libtest::test_exception) {
 /** \test Tests the projection of the C4(+) group in a 4-space onto
         a 2-space, C1
  **/
-void permutation_group_test::test_project_down_2()
-throw(libtest::test_exception) {
+void permutation_group_test::test_project_down_2() {
 
     static const char *testname =
             "permutation_group_test::test_project_down_2()";
@@ -551,8 +549,7 @@ throw(libtest::test_exception) {
 /** \test Tests the projection of the S4(-) group in a 4-space onto
         a 2-space, S2(-)
  **/
-void permutation_group_test::test_project_down_3()
-throw(libtest::test_exception) {
+void permutation_group_test::test_project_down_3() {
 
     static const char *testname =
             "permutation_group_test::test_project_down_3()";
@@ -594,8 +591,7 @@ throw(libtest::test_exception) {
 /** \test Tests the projection of the S2(-) group in a 2-space onto
         a 1-space
  **/
-void permutation_group_test::test_project_down_4()
-throw(libtest::test_exception) {
+void permutation_group_test::test_project_down_4() {
 
     static const char *testname =
             "permutation_group_test::test_project_down_4()";
@@ -631,8 +627,7 @@ throw(libtest::test_exception) {
 /** \test Tests a symmetric perm group in a 6-space
     \sa test_8
  **/
-void permutation_group_test::test_project_down_8a()
-throw(libtest::test_exception) {
+void permutation_group_test::test_project_down_8a() {
 
     static const char *testname =
             "permutation_group_test::test_project_down_8a()";
@@ -676,8 +671,7 @@ throw(libtest::test_exception) {
 /** \test Tests a symmetric perm group in a 6-space
     \sa test_8
  **/
-void permutation_group_test::test_project_down_8b()
-throw(libtest::test_exception) {
+void permutation_group_test::test_project_down_8b() {
 
     static const char *testname =
             "permutation_group_test::test_project_down_8b()";
@@ -720,8 +714,7 @@ throw(libtest::test_exception) {
 
 /** \test Stabilize element set {1, 3} in group S6 returning S4.
  **/
-void permutation_group_test::test_stabilize_1()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize_1() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize_1()";
@@ -769,8 +762,7 @@ throw(libtest::test_exception) {
 
 /** \test Stabilize element set {1,3} in group [ijkl] = [klij]
  **/
-void permutation_group_test::test_stabilize_2()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize_2() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize_2()";
@@ -805,8 +797,7 @@ throw(libtest::test_exception) {
 /** \test Stabilize element set {1,2} in group S2 x S2 with
            pairwise permutation
  **/
-void permutation_group_test::test_stabilize_3()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize_3() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize_3()";
@@ -848,8 +839,7 @@ throw(libtest::test_exception) {
 /** \test Stabilize element set {0,2} in group A2 x A2 with
            pairwise permutation
  **/
-void permutation_group_test::test_stabilize_4()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize_4() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize_4()";
@@ -886,8 +876,7 @@ throw(libtest::test_exception) {
 /** \test Stabilize element set {0,1} in group A2 x A2 with
            pairwise permutation
  **/
-void permutation_group_test::test_stabilize_5()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize_5() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize_5()";
@@ -926,8 +915,7 @@ throw(libtest::test_exception) {
 
 /** \test Stabilize element set {2, 3, 4} in group S5
  **/
-void permutation_group_test::test_stabilize_6()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize_6() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize_6()";
@@ -963,8 +951,7 @@ throw(libtest::test_exception) {
 /** \test Stabilize element set {0,3} in group A2 x A2 with
            pairwise permutation
  **/
-void permutation_group_test::test_stabilize_7()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize_7() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize_7()";
@@ -1001,8 +988,7 @@ throw(libtest::test_exception) {
 }
 
 
-void permutation_group_test::test_stabilize2_1()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize2_1() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize2_1()";
@@ -1041,8 +1027,7 @@ throw(libtest::test_exception) {
 }
 
 
-void permutation_group_test::test_stabilize2_2()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize2_2() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize2_2()";
@@ -1094,8 +1079,7 @@ throw(libtest::test_exception) {
 }
 
 
-void permutation_group_test::test_stabilize4_1()
-throw(libtest::test_exception) {
+void permutation_group_test::test_stabilize4_1() {
 
     static const char *testname =
             "permutation_group_test::test_stabilize4_1()";
@@ -1293,8 +1277,7 @@ void permutation_group_test::test_permute_3() {
 
 template<size_t N, typename T>
 void permutation_group_test::verify_group(const char *testname,
-        const std::list< std::pair<permutation<N>, scalar_transf<T> > > &lst)
-throw(libtest::test_exception) {
+        const std::list< std::pair<permutation<N>, scalar_transf<T> > > &lst) {
 
     typedef std::pair<permutation<N>, scalar_transf<T> > gen_perm_t;
     typedef std::list<gen_perm_t> perm_list_t;
@@ -1405,9 +1388,7 @@ void permutation_group_test::verify_members(const char *testname,
 
 template<size_t N, typename T>
 void permutation_group_test::verify_genset(const char *testname,
-        const permutation_group<N, T> &grp,
-        const std::list< std::pair<permutation<N>, scalar_transf<T> > > &allowed)
-throw(libtest::test_exception) {
+        const permutation_group<N, T> &grp, const std::list< std::pair<permutation<N>, scalar_transf<T> > > &allowed) {
 
     typedef std::pair<permutation<N>, scalar_transf<T> > gen_perm_t;
     typedef std::list<gen_perm_t> perm_list_t;

--- a/tests/symmetry/permutation_group_test.h
+++ b/tests/symmetry/permutation_group_test.h
@@ -15,43 +15,43 @@ namespace libtensor {
  **/
 class permutation_group_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2a() throw(libtest::test_exception);
-    void test_2b() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5a() throw(libtest::test_exception);
-    void test_5b() throw(libtest::test_exception);
-    void test_6a() throw(libtest::test_exception);
-    void test_6b() throw(libtest::test_exception);
-    void test_7() throw(libtest::test_exception);
-    void test_8() throw(libtest::test_exception);
+    void test_1();
+    void test_2a();
+    void test_2b();
+    void test_3();
+    void test_4();
+    void test_5a();
+    void test_5b();
+    void test_6a();
+    void test_6b();
+    void test_7();
+    void test_8();
 
-    void test_project_down_1() throw(libtest::test_exception);
-    void test_project_down_2() throw(libtest::test_exception);
-    void test_project_down_3() throw(libtest::test_exception);
-    void test_project_down_4() throw(libtest::test_exception);
-    void test_project_down_8a() throw(libtest::test_exception);
-    void test_project_down_8b() throw(libtest::test_exception);
+    void test_project_down_1();
+    void test_project_down_2();
+    void test_project_down_3();
+    void test_project_down_4();
+    void test_project_down_8a();
+    void test_project_down_8b();
 
-    void test_stabilize_1() throw(libtest::test_exception);
-    void test_stabilize_2() throw(libtest::test_exception);
-    void test_stabilize_3() throw(libtest::test_exception);
-    void test_stabilize_4() throw(libtest::test_exception);
-    void test_stabilize_5() throw(libtest::test_exception);
-    void test_stabilize_6() throw(libtest::test_exception);
-    void test_stabilize_7() throw(libtest::test_exception);
+    void test_stabilize_1();
+    void test_stabilize_2();
+    void test_stabilize_3();
+    void test_stabilize_4();
+    void test_stabilize_5();
+    void test_stabilize_6();
+    void test_stabilize_7();
 
-    void test_stabilize2_1() throw(libtest::test_exception);
-    void test_stabilize2_2() throw(libtest::test_exception);
-    void test_stabilize4_1() throw(libtest::test_exception);
+    void test_stabilize2_1();
+    void test_stabilize2_2();
+    void test_stabilize4_1();
 
-    void test_permute_1() throw(libtest::test_exception);
-    void test_permute_2() throw(libtest::test_exception);
-    void test_permute_3() throw(libtest::test_exception);
+    void test_permute_1();
+    void test_permute_2();
+    void test_permute_3();
 
 private:
     typedef scalar_transf<double> transf_t;
@@ -59,19 +59,19 @@ private:
     template<size_t N, typename T>
     void verify_group(const char *testname,
             const std::list< std::pair<permutation<N>, scalar_transf<T> > > &lst)
-    throw(libtest::test_exception);
+   ;
 
     template<size_t N, typename T>
     void verify_members(const char *testname,
             const permutation_group<N, T> &grp, const scalar_transf<T> &tr,
             const std::list< std::pair<permutation<N>, scalar_transf<T> > > &allowed)
-    throw(libtest::test_exception);
+   ;
 
     template<size_t N, typename T>
     void verify_genset(const char *testname,
             const permutation_group<N, T> &grp,
             const std::list< std::pair<permutation<N>, scalar_transf<T> > > &allowed)
-    throw(libtest::test_exception);
+   ;
 
     template<size_t N, typename T>
     void gen_group(

--- a/tests/symmetry/point_group_table_test.C
+++ b/tests/symmetry/point_group_table_test.C
@@ -4,7 +4,7 @@
 namespace libtensor {
 
 
-void point_group_table_test::perform() throw(libtest::test_exception) {
+void point_group_table_test::perform() {
 
     test_1();
     test_2();
@@ -15,7 +15,7 @@ void point_group_table_test::perform() throw(libtest::test_exception) {
 
 /** \test Point group C2h.
  **/
-void point_group_table_test::test_1() throw(libtest::test_exception) {
+void point_group_table_test::test_1() {
 
     static const char *testname = "point_group_table_test::test_1()";
 
@@ -84,7 +84,7 @@ void point_group_table_test::test_1() throw(libtest::test_exception) {
 
 /** \test Wrongly setup product table
  **/
-void point_group_table_test::test_2() throw(libtest::test_exception) {
+void point_group_table_test::test_2() {
 
     static const char *testname = "point_group_table_test::test_2()";
 
@@ -117,7 +117,7 @@ void point_group_table_test::test_2() throw(libtest::test_exception) {
 
 /** \test Clone method
  **/
-void point_group_table_test::test_3() throw(libtest::test_exception) {
+void point_group_table_test::test_3() {
 
     static const char *testname = "point_group_table_test::test_3()";
 
@@ -148,7 +148,7 @@ void point_group_table_test::test_3() throw(libtest::test_exception) {
 
 /** \test Product evaluation for product table
  **/
-void point_group_table_test::test_4() throw(libtest::test_exception) {
+void point_group_table_test::test_4() {
 
     static const char *testname = "point_group_table_test::test_4()";
 

--- a/tests/symmetry/point_group_table_test.h
+++ b/tests/symmetry/point_group_table_test.h
@@ -12,13 +12,13 @@ namespace libtensor {
  **/
 class point_group_table_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
 };
 
 

--- a/tests/symmetry/product_rule_test.C
+++ b/tests/symmetry/product_rule_test.C
@@ -4,7 +4,7 @@
 namespace libtensor {
 
 
-void product_rule_test::perform() throw(libtest::test_exception) {
+void product_rule_test::perform() {
 
     test_1();
     test_2();
@@ -14,7 +14,7 @@ void product_rule_test::perform() throw(libtest::test_exception) {
 
 /** \test Add terms to product rule
  **/
-void product_rule_test::test_1() throw(libtest::test_exception) {
+void product_rule_test::test_1() {
 
     static const char *testname = "product_rule_test::test_1()";
 
@@ -75,7 +75,7 @@ void product_rule_test::test_1() throw(libtest::test_exception) {
 
 /** \test Add terms with identical sequence to product rule
  **/
-void product_rule_test::test_2() throw(libtest::test_exception) {
+void product_rule_test::test_2() {
 
     static const char *testname = "product_rule_test::test_2()";
 
@@ -136,7 +136,7 @@ void product_rule_test::test_2() throw(libtest::test_exception) {
 
 /** \test Compare to product rules
  **/
-void product_rule_test::test_3() throw(libtest::test_exception) {
+void product_rule_test::test_3() {
 
     static const char *testname = "product_rule_test::test_3()";
 

--- a/tests/symmetry/product_rule_test.h
+++ b/tests/symmetry/product_rule_test.h
@@ -11,12 +11,12 @@ namespace libtensor {
  **/
 class product_rule_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/product_table_container_test.C
+++ b/tests/symmetry/product_table_container_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void product_table_container_test::perform() throw(libtest::test_exception) {
+void product_table_container_test::perform() {
 
     test_1();
     test_2();
@@ -15,7 +15,7 @@ void product_table_container_test::perform() throw(libtest::test_exception) {
 
 /** \test Add tables to prodcut_table_container
  **/
-void product_table_container_test::test_1() throw(libtest::test_exception) {
+void product_table_container_test::test_1() {
 
     static const char *testname = "product_table_container_test::test_1()";
 
@@ -84,7 +84,7 @@ void product_table_container_test::test_1() throw(libtest::test_exception) {
 
 /** \test Requesting and returning tables
  **/
-void product_table_container_test::test_2() throw(libtest::test_exception) {
+void product_table_container_test::test_2() {
 
     static const char *testname = "product_table_container_test::test_2()";
 
@@ -184,7 +184,7 @@ void product_table_container_test::test_2() throw(libtest::test_exception) {
 
 /** \test Deleting tables
  **/
-void product_table_container_test::test_3() throw(libtest::test_exception) {
+void product_table_container_test::test_3() {
 
     static const char *testname = "product_table_container_test::test_3()";
 

--- a/tests/symmetry/product_table_container_test.h
+++ b/tests/symmetry/product_table_container_test.h
@@ -12,12 +12,12 @@ namespace libtensor {
  **/
 class product_table_container_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
 };
 
 

--- a/tests/symmetry/se_label_test.C
+++ b/tests/symmetry/se_label_test.C
@@ -6,7 +6,7 @@
 
 namespace libtensor {
 
-void se_label_test::perform() throw(libtest::test_exception) {
+void se_label_test::perform() {
 
     std::string s6("S6");
     setup_pg_table(s6);
@@ -30,7 +30,7 @@ void se_label_test::perform() throw(libtest::test_exception) {
 /** \test Tests setting evaluation rules
  **/
 void se_label_test::test_basic_1(
-    const std::string &table_id) throw(libtest::test_exception) {
+    const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "se_label_test::test_basic_1(" << table_id << ")";
@@ -135,7 +135,7 @@ void se_label_test::test_basic_1(
 /** \test Four blocks, all labeled, different index types, basic rules only
  **/
 void se_label_test::test_allowed_1(
-    const std::string &table_id) throw(libtest::test_exception) {
+    const std::string &table_id) {
     
     std::ostringstream tnss;
     tnss << "se_label_test::test_allowed_1(" << table_id << ")";
@@ -185,7 +185,7 @@ void se_label_test::test_allowed_1(
         unlabeled dimension
  **/
 void se_label_test::test_allowed_2(
-    const std::string &table_id) throw(libtest::test_exception) {
+    const std::string &table_id) {
     
     std::ostringstream tnss;
     tnss << "se_label_test::test_allowed_2(" << table_id << ")";
@@ -227,7 +227,7 @@ void se_label_test::test_allowed_2(
 /** \test Four blocks, all dims labeled, composite rules
  **/
 void se_label_test::test_allowed_3(
-    const std::string &table_id) throw(libtest::test_exception) {
+    const std::string &table_id) {
     
     std::ostringstream tnss;
     tnss << "se_label_test::test_allowed_3(" << table_id << ")";
@@ -281,7 +281,7 @@ void se_label_test::test_allowed_3(
         permute
  **/
 void se_label_test::test_permute_1(
-    const std::string &table_id) throw(libtest::test_exception) {
+    const std::string &table_id) {
     
     std::ostringstream tnss;
     tnss << "se_label_test::test_permute_1(" << table_id << ")";
@@ -354,7 +354,7 @@ void se_label_test::test_permute_1(
 /** \test Four blocks, all dims labeled, composite rules, permuted
  **/
 void se_label_test::test_permute_2(
-    const std::string &table_id) throw(libtest::test_exception) {
+    const std::string &table_id) {
     
     std::ostringstream tnss;
     tnss << "se_label_test::test_permute_2(" << table_id << ")";

--- a/tests/symmetry/se_label_test.h
+++ b/tests/symmetry/se_label_test.h
@@ -12,21 +12,21 @@ namespace libtensor {
  **/
 class se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_basic_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_allowed_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_allowed_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_allowed_3(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_permute_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_permute_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/se_label_test_base.C
+++ b/tests/symmetry/se_label_test_base.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 void se_label_test_base::setup_pg_table(
-        const std::string &id) throw(libtest::test_exception){
+        const std::string &id){
 
     if (id == "Cs" || id == "cs") {
 
@@ -101,7 +101,7 @@ void se_label_test_base::setup_pg_table(
 }
 
 void se_label_test_base::clear_pg_table(
-        const std::string &id) throw(libtest::test_exception){
+        const std::string &id){
 
     if (product_table_container::get_instance().table_exists(id)) {
         product_table_container::get_instance().erase(id);

--- a/tests/symmetry/se_label_test_base.h
+++ b/tests/symmetry/se_label_test_base.h
@@ -23,13 +23,13 @@ protected:
         Valid values of table ID are C2v (abelian point group) and S6.
      **/
     void setup_pg_table(
-            const std::string &id) throw(libtest::test_exception);
+            const std::string &id);
 
     /** \brief Removes point group table with given ID
         \param id to access the table
      **/
     void clear_pg_table(
-            const std::string &id) throw(libtest::test_exception);
+            const std::string &id);
 
     /** \brief Checks the allowed blocks of a symmetry element against a
             reference
@@ -47,14 +47,14 @@ protected:
     template<size_t N>
     void check_allowed(const char *testname, const char *sename, 
             const se_label<N, double> &se, const std::vector<bool> &expected)
-        throw(libtest::test_exception);
+       ;
 };
 
 template<size_t N>
 void se_label_test_base::check_allowed(
         const char *testname, const char *sename,
         const se_label<N, double> &se, const std::vector<bool> &expected)
-    throw(libtest::test_exception) {
+    {
 
     const block_labeling<N> &bl = se.get_labeling();
     const dimensions<N> &bidims = bl.get_block_index_dims();

--- a/tests/symmetry/se_part_test.C
+++ b/tests/symmetry/se_part_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void se_part_test::perform() throw(libtest::test_exception) {
+void se_part_test::perform() {
 
     test_1();
     test_2();
@@ -27,7 +27,7 @@ void se_part_test::perform() throw(libtest::test_exception) {
 
 /** \test Two partitions, one block in each partition (2-dim)
  **/
-void se_part_test::test_1() throw(libtest::test_exception) {
+void se_part_test::test_1() {
 
     static const char *testname = "se_part_test::test_1()";
 
@@ -142,7 +142,7 @@ void se_part_test::test_1() throw(libtest::test_exception) {
 
 /** \test Two partitions, two blocks in each partition (2-dim)
  **/
-void se_part_test::test_2() throw(libtest::test_exception) {
+void se_part_test::test_2() {
 
     static const char *testname = "se_part_test::test_2()";
 
@@ -256,7 +256,7 @@ void se_part_test::test_2() throw(libtest::test_exception) {
 /** \test Two partitions, two or three blocks in each partition (4-dim),
         block sizes vary for different dimensions
  **/
-void se_part_test::test_3a() throw(libtest::test_exception) {
+void se_part_test::test_3a() {
 
     static const char *testname = "se_part_test::test_3a()";
 
@@ -347,7 +347,7 @@ void se_part_test::test_3a() throw(libtest::test_exception) {
 /** \test Two partitions, two or three blocks in each partition (4-dim),
         block sizes vary for different dimensions.
  **/
-void se_part_test::test_3b() throw(libtest::test_exception) {
+void se_part_test::test_3b() {
 
     static const char *testname = "se_part_test::test_3b()";
 
@@ -437,7 +437,7 @@ void se_part_test::test_3b() throw(libtest::test_exception) {
 /** \test Two partitions, two or three blocks in each partition (4-dim),
         block sizes vary for different dimensions.
  **/
-void se_part_test::test_4() throw(libtest::test_exception) {
+void se_part_test::test_4() {
 
     static const char *testname = "se_part_test::test_4()";
 
@@ -492,7 +492,7 @@ void se_part_test::test_4() throw(libtest::test_exception) {
 
 /** \test Two partitions, two blocks in each partition (2-dim), forbidden
  **/
-void se_part_test::test_5() throw(libtest::test_exception) {
+void se_part_test::test_5() {
 
     static const char *testname = "se_part_test::test_5()";
 
@@ -599,7 +599,7 @@ void se_part_test::test_5() throw(libtest::test_exception) {
 /** \test Test creation of maps between forbidden partitions and
         forbidden partitions in existing maps
  **/
-void se_part_test::test_6() throw(libtest::test_exception) {
+void se_part_test::test_6() {
 
     static const char *testname = "se_part_test::test_6()";
 
@@ -758,7 +758,7 @@ void se_part_test::test_6() throw(libtest::test_exception) {
 /** \test Permutation of se_part: two partitions, two or three blocks in
         each partition (4-dim), block sizes vary for different dimensions
  **/
-void se_part_test::test_perm_1() throw(libtest::test_exception) {
+void se_part_test::test_perm_1() {
 
     static const char *testname = "se_part_test::test_perm_1()";
 
@@ -819,7 +819,7 @@ void se_part_test::test_perm_1() throw(libtest::test_exception) {
 /** \test Permutation of se_part: two partitions, two or three blocks in
         each partition (4-dim), block sizes vary for different dimensions
  **/
-void se_part_test::test_perm_2() throw(libtest::test_exception) {
+void se_part_test::test_perm_2() {
 
     static const char *testname = "se_part_test::test_perm_2()";
 
@@ -882,7 +882,7 @@ void se_part_test::test_perm_2() throw(libtest::test_exception) {
 /** \test Permutation of se_part: two partitions, two or three blocks in
         each partition (4-dim), block sizes vary for different dimensions
  **/
-void se_part_test::test_perm_3() throw(libtest::test_exception) {
+void se_part_test::test_perm_3() {
 
     static const char *testname = "se_part_test::test_perm_3()";
 
@@ -944,7 +944,7 @@ void se_part_test::test_perm_3() throw(libtest::test_exception) {
 /** \test Permutation of se_part: two partitions, two or three blocks in
         each partition (4-dim), block sizes vary for different dimensions
  **/
-void se_part_test::test_perm_4() throw(libtest::test_exception) {
+void se_part_test::test_perm_4() {
 
     static const char *testname = "se_part_test::test_perm_4()";
 
@@ -1010,7 +1010,7 @@ void se_part_test::test_perm_4() throw(libtest::test_exception) {
         each partition (2-dim), block sizes vary for different dimensions,
         forbidden partitions
  **/
-void se_part_test::test_perm_5() throw(libtest::test_exception) {
+void se_part_test::test_perm_5() {
 
     static const char *testname = "se_part_test::test_perm_5()";
 
@@ -1074,7 +1074,7 @@ void se_part_test::test_perm_5() throw(libtest::test_exception) {
 
 /** \test Two partitions, blocks with unequal size in each partition (2-dim)
  **/
-void se_part_test::test_exc() throw(libtest::test_exception) {
+void se_part_test::test_exc() {
 
     static const char *testname = "se_part_test::test_exc()";
 

--- a/tests/symmetry/se_part_test.h
+++ b/tests/symmetry/se_part_test.h
@@ -11,22 +11,22 @@ namespace libtensor {
  **/
 class se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3a() throw(libtest::test_exception);
-    void test_3b() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
-    void test_6() throw(libtest::test_exception);
-    void test_perm_1() throw(libtest::test_exception);
-    void test_perm_2() throw(libtest::test_exception);
-    void test_perm_3() throw(libtest::test_exception);
-    void test_perm_4() throw(libtest::test_exception);
-    void test_perm_5() throw(libtest::test_exception);
-    void test_exc() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3a();
+    void test_3b();
+    void test_4();
+    void test_5();
+    void test_6();
+    void test_perm_1();
+    void test_perm_2();
+    void test_perm_3();
+    void test_perm_4();
+    void test_perm_5();
+    void test_exc();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/se_perm_test.C
+++ b/tests/symmetry/se_perm_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void se_perm_test::perform() throw(libtest::test_exception) {
+void se_perm_test::perform() {
 
     test_sym_ab_ba();
     test_asym_ab_ba();
@@ -18,7 +18,7 @@ void se_perm_test::perform() throw(libtest::test_exception) {
 
 /** \test Tests the ab->ba permutational symmetry element
  **/
-void se_perm_test::test_sym_ab_ba() throw(libtest::test_exception) {
+void se_perm_test::test_sym_ab_ba() {
 
     static const char *testname = "se_perm_test::test_sym_ab_ba()";
 
@@ -86,7 +86,7 @@ void se_perm_test::test_sym_ab_ba() throw(libtest::test_exception) {
 
 /** \test Tests the ab->ba permutational anti-symmetry element
  **/
-void se_perm_test::test_asym_ab_ba() throw(libtest::test_exception) {
+void se_perm_test::test_asym_ab_ba() {
 
     static const char *testname = "se_perm_test::test_asym_ab_ba()";
 
@@ -154,7 +154,7 @@ void se_perm_test::test_asym_ab_ba() throw(libtest::test_exception) {
 
 /** \test Tests the abc->bca permutational symmetry element
  **/
-void se_perm_test::test_sym_abc_bca() throw(libtest::test_exception) {
+void se_perm_test::test_sym_abc_bca() {
 
     static const char *testname = "se_perm_test::test_sym_abc_bca()";
 
@@ -222,7 +222,7 @@ void se_perm_test::test_sym_abc_bca() throw(libtest::test_exception) {
 
 /** \test Tests the abc->bca permutational anti-symmetry element.
  **/
-void se_perm_test::test_asym_abc_bca() throw(libtest::test_exception) {
+void se_perm_test::test_asym_abc_bca() {
 
     static const char *testname = "se_perm_test::test_asym_abc_bca()";
 
@@ -247,7 +247,7 @@ void se_perm_test::test_asym_abc_bca() throw(libtest::test_exception) {
 
 /** \test Tests the abcd->badc permutational symmetry element
  **/
-void se_perm_test::test_sym_abcd_badc() throw(libtest::test_exception) {
+void se_perm_test::test_sym_abcd_badc() {
 
     static const char *testname = "se_perm_test::test_sym_abcd_badc()";
 
@@ -324,7 +324,7 @@ void se_perm_test::test_sym_abcd_badc() throw(libtest::test_exception) {
 
 /** \test Tests the abcd->badc permutational anti-symmetry element
  **/
-void se_perm_test::test_asym_abcd_badc() throw(libtest::test_exception) {
+void se_perm_test::test_asym_abcd_badc() {
 
     static const char *testname = "se_perm_test::test_asym_abcd_badc()";
 

--- a/tests/symmetry/se_perm_test.h
+++ b/tests/symmetry/se_perm_test.h
@@ -11,15 +11,15 @@ namespace libtensor {
  **/
 class se_perm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_sym_ab_ba() throw(libtest::test_exception);
-    void test_asym_ab_ba() throw(libtest::test_exception);
-    void test_sym_abc_bca() throw(libtest::test_exception);
-    void test_asym_abc_bca() throw(libtest::test_exception);
-    void test_sym_abcd_badc() throw(libtest::test_exception);
-    void test_asym_abcd_badc() throw(libtest::test_exception);
+    void test_sym_ab_ba();
+    void test_asym_ab_ba();
+    void test_sym_abc_bca();
+    void test_asym_abc_bca();
+    void test_sym_abcd_badc();
+    void test_asym_abcd_badc();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/so_apply_se_label_test.C
+++ b/tests/symmetry/so_apply_se_label_test.C
@@ -7,7 +7,7 @@
 
 namespace libtensor {
 
-void so_apply_se_label_test::perform() throw(libtest::test_exception) {
+void so_apply_se_label_test::perform() {
 
     std::string table_id = "S6";
     setup_pg_table(table_id);
@@ -35,7 +35,7 @@ void so_apply_se_label_test::perform() throw(libtest::test_exception) {
  **/
 void so_apply_se_label_test::test_1(
         const std::string &table_id, bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_apply_se_label_test::test_1(" << table_id << ", "

--- a/tests/symmetry/so_apply_se_label_test.h
+++ b/tests/symmetry/so_apply_se_label_test.h
@@ -12,11 +12,11 @@ namespace libtensor {
  **/
 class so_apply_se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1(const std::string &table_id, bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/so_apply_se_part_test.C
+++ b/tests/symmetry/so_apply_se_part_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void so_apply_se_part_test::perform() throw(libtest::test_exception) {
+void so_apply_se_part_test::perform() {
 
     test_1(false,  true, false);
     test_1(false, false, false);
@@ -32,7 +32,7 @@ void so_apply_se_part_test::perform() throw(libtest::test_exception) {
 /** \test Tests that application on an empty set yields an empty set
  **/
 void so_apply_se_part_test::test_1(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss <<  "so_apply_se_part_test::test_1(" << keep_zero << ", "
@@ -88,7 +88,7 @@ void so_apply_se_part_test::test_1(bool keep_zero,
 /** \test Tests application on a non-empty set.
  **/
 void so_apply_se_part_test::test_2(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss <<  "so_apply_se_part_test::test_2(" << keep_zero << ", "
@@ -181,7 +181,7 @@ void so_apply_se_part_test::test_2(bool keep_zero,
 /** \test Tests application on non-empty set with permutation
  **/
 void so_apply_se_part_test::test_3(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss <<  "so_apply_se_part_test::test_3(" << keep_zero << ", "

--- a/tests/symmetry/so_apply_se_part_test.h
+++ b/tests/symmetry/so_apply_se_part_test.h
@@ -12,15 +12,15 @@ namespace libtensor {
  **/
 class so_apply_se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
     void test_2(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
     void test_3(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
 
 };
 

--- a/tests/symmetry/so_apply_se_perm_test.C
+++ b/tests/symmetry/so_apply_se_perm_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void so_apply_se_perm_test::perform() throw(libtest::test_exception) {
+void so_apply_se_perm_test::perform() {
 
     test_1(false, false, false);
     test_1(false, false,  true);
@@ -32,7 +32,7 @@ void so_apply_se_perm_test::perform() throw(libtest::test_exception) {
 /** \test Tests that an empty sets yields an empty set
  **/
 void so_apply_se_perm_test::test_1(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_apply_se_perm_test::test_1(" << keep_zero << ", "
@@ -79,7 +79,7 @@ void so_apply_se_perm_test::test_1(bool keep_zero,
 /** \test Tests the application on a non-empty set
  **/
 void so_apply_se_perm_test::test_2(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_apply_se_perm_test::test_2(" << keep_zero << ", "
@@ -137,7 +137,7 @@ void so_apply_se_perm_test::test_2(bool keep_zero,
 /** \test Tests the application on a non-empty set with permutation
  **/
 void so_apply_se_perm_test::test_3(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_apply_se_perm_test::test_3(" << keep_zero << ", "

--- a/tests/symmetry/so_apply_se_perm_test.h
+++ b/tests/symmetry/so_apply_se_perm_test.h
@@ -12,15 +12,15 @@ namespace libtensor {
  **/
 class so_apply_se_perm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
     void test_2(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
     void test_3(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
 
 };
 

--- a/tests/symmetry/so_apply_test.C
+++ b/tests/symmetry/so_apply_test.C
@@ -8,7 +8,7 @@
 namespace libtensor {
 
 
-void so_apply_test::perform() throw(libtest::test_exception) {
+void so_apply_test::perform() {
 
     test_1( true, true, false);
     test_1(false, true, false);
@@ -34,7 +34,7 @@ void so_apply_test::perform() throw(libtest::test_exception) {
 /** \test Empty %symmetry in 4-space.
  **/
 void so_apply_test::test_1(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_apply_test::test_1(" << keep_zero << ", " << is_asym << ", "
@@ -68,7 +68,7 @@ void so_apply_test::test_1(bool keep_zero,
 /** \test Non-empty perm %symmetry in 4-space.
  **/
 void so_apply_test::test_2(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_apply_test::test_2(" << keep_zero << ", " << is_asym << ", "
@@ -109,7 +109,7 @@ void so_apply_test::test_2(bool keep_zero,
 /** \test Non-empty perm %symmetry in 4-space with permutation.
  **/
 void so_apply_test::test_3(bool keep_zero,
-        bool is_asym, bool sign) throw(libtest::test_exception) {
+        bool is_asym, bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_apply_test::test_3(" << keep_zero << ", "

--- a/tests/symmetry/so_apply_test.h
+++ b/tests/symmetry/so_apply_test.h
@@ -11,15 +11,15 @@ namespace libtensor {
 **/
 class so_apply_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_1(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
     void test_2(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
     void test_3(bool keep_zero,
-            bool is_asym, bool sign) throw(libtest::test_exception);
+            bool is_asym, bool sign);
 
 };
 

--- a/tests/symmetry/so_copy_test.C
+++ b/tests/symmetry/so_copy_test.C
@@ -5,7 +5,7 @@
 namespace libtensor {
 
 
-void so_copy_test::perform() throw(libtest::test_exception) {
+void so_copy_test::perform() {
 
     test_1();
     test_2();
@@ -76,7 +76,7 @@ using namespace so_copy_test_ns;
 
 /** \test Copy of empty %symmetry in 4-space.
  **/
-void so_copy_test::test_1() throw(libtest::test_exception) {
+void so_copy_test::test_1() {
 
     static const char *testname = "so_copy_test::test_1()";
 
@@ -113,7 +113,7 @@ void so_copy_test::test_1() throw(libtest::test_exception) {
 
 /** \test Copy of %symmetry that contains one element in 4-space.
  **/
-void so_copy_test::test_2() throw(libtest::test_exception) {
+void so_copy_test::test_2() {
 
     static const char *testname = "so_copy_test::test_2()";
 
@@ -216,7 +216,7 @@ void so_copy_test::test_2() throw(libtest::test_exception) {
 }
 
 
-void so_copy_test::test_3() throw(libtest::test_exception) {
+void so_copy_test::test_3() {
 
     static const char *testname = "so_copy_test::test_3()";
 

--- a/tests/symmetry/so_copy_test.h
+++ b/tests/symmetry/so_copy_test.h
@@ -11,12 +11,12 @@ namespace libtensor {
 **/
 class so_copy_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
 
 };
 

--- a/tests/symmetry/so_dirprod_se_label_test.C
+++ b/tests/symmetry/so_dirprod_se_label_test.C
@@ -6,7 +6,7 @@
 
 namespace libtensor {
 
-void so_dirprod_se_label_test::perform() throw(libtest::test_exception) {
+void so_dirprod_se_label_test::perform() {
 
     std::string table_id("S6");
     setup_pg_table(table_id);
@@ -36,7 +36,7 @@ void so_dirprod_se_label_test::perform() throw(libtest::test_exception) {
         group of a higher order
  **/
 void so_dirprod_se_label_test::test_empty_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_label_test::test_empty_1(" << table_id << ")";
@@ -79,7 +79,7 @@ void so_dirprod_se_label_test::test_empty_1(
         empty group (1-space) forming a 3-space.
  **/
 void so_dirprod_se_label_test::test_empty_2(
-        const std::string &table_id, bool perm) throw(libtest::test_exception) {
+        const std::string &table_id, bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_label_test::test_empty_2("
@@ -165,7 +165,7 @@ void so_dirprod_se_label_test::test_empty_2(
         element of Eu symmetry in 2-space forming a 3-space.
  **/
 void so_dirprod_se_label_test::test_empty_3(
-        const std::string &table_id, bool perm) throw(libtest::test_exception) {
+        const std::string &table_id, bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_label_test::test_empty_3("
@@ -257,7 +257,7 @@ void so_dirprod_se_label_test::test_empty_3(
 /** \test Direct product of a group in 1-space and a group in 2-space.
  **/
 void so_dirprod_se_label_test::test_nn_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_label_test::test_nn_1(" << table_id << ")";
@@ -337,7 +337,7 @@ void so_dirprod_se_label_test::test_nn_1(
         result is permuted with [012->120].
  **/
 void so_dirprod_se_label_test::test_nn_2(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_label_test::test_nn_2(" << table_id << ")";
@@ -419,7 +419,7 @@ void so_dirprod_se_label_test::test_nn_2(
         has a composite rule
  **/
 void so_dirprod_se_label_test::test_nn_3(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_label_test::test_nn_3(" << table_id << ")";
@@ -510,7 +510,7 @@ void so_dirprod_se_label_test::test_nn_3(
 
 /** \test Direct product of two groups in 2-space.
  **/
-void so_dirprod_se_label_test::test_nn_4() throw(libtest::test_exception) {
+void so_dirprod_se_label_test::test_nn_4() {
 
     const char testname[] = "so_dirprod_se_label_test::test_nn_4()";
 

--- a/tests/symmetry/so_dirprod_se_label_test.h
+++ b/tests/symmetry/so_dirprod_se_label_test.h
@@ -13,19 +13,19 @@ namespace libtensor {
  **/
 class so_dirprod_se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_empty_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_empty_2(const std::string &table_id,
-            bool perm) throw(libtest::test_exception);
+            bool perm);
     void test_empty_3(const std::string &table_id,
-            bool perm) throw(libtest::test_exception);
-    void test_nn_1(const std::string &table_id) throw(libtest::test_exception);
-    void test_nn_2(const std::string &table_id) throw(libtest::test_exception);
-    void test_nn_3(const std::string &table_id) throw(libtest::test_exception);
-    void test_nn_4() throw(libtest::test_exception);
+            bool perm);
+    void test_nn_1(const std::string &table_id);
+    void test_nn_2(const std::string &table_id);
+    void test_nn_3(const std::string &table_id);
+    void test_nn_4();
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/so_dirprod_se_part_test.C
+++ b/tests/symmetry/so_dirprod_se_part_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void so_dirprod_se_part_test::perform() throw(libtest::test_exception) {
+void so_dirprod_se_part_test::perform() {
 
     test_empty_1();
     test_empty_2(true);
@@ -27,7 +27,7 @@ void so_dirprod_se_part_test::perform() throw(libtest::test_exception) {
 /** \test Tests that the direct product of two empty group yields an empty
         group of a higher order
  **/
-void so_dirprod_se_part_test::test_empty_1() throw(libtest::test_exception) {
+void so_dirprod_se_part_test::test_empty_1() {
 
     static const char *testname =
             "so_dirprod_se_part_test::test_empty_1()";
@@ -74,7 +74,7 @@ void so_dirprod_se_part_test::test_empty_1() throw(libtest::test_exception) {
         group (1-space) forming a 3-space.
  **/
 void so_dirprod_se_part_test::test_empty_2(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_part_test::test_empty_2(" << perm << ")";
@@ -161,7 +161,7 @@ void so_dirprod_se_part_test::test_empty_2(
         in 2-space forming a 3-space.
  **/
 void so_dirprod_se_part_test::test_empty_3(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_part_test::test_empty_3(" << perm << ")";
@@ -248,7 +248,7 @@ void so_dirprod_se_part_test::test_empty_3(
 /** \test Direct product of a group in 1-space and a group in 2-space.
  **/
 void so_dirprod_se_part_test::test_nn_1(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_part_test::test_nn_1(" << symm1 << ", "
@@ -336,7 +336,7 @@ void so_dirprod_se_part_test::test_nn_1(
         result is permuted with [012->120].
  **/
 void so_dirprod_se_part_test::test_nn_2(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_part_test::test_nn_2(" << symm1 << ", "

--- a/tests/symmetry/so_dirprod_se_part_test.h
+++ b/tests/symmetry/so_dirprod_se_part_test.h
@@ -13,14 +13,14 @@ namespace libtensor {
  **/
 class so_dirprod_se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2(bool perm) throw(libtest::test_exception);
-    void test_empty_3(bool perm) throw(libtest::test_exception);
-    void test_nn_1(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_nn_2(bool symm1, bool symm2) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2(bool perm);
+    void test_empty_3(bool perm);
+    void test_nn_1(bool symm1, bool symm2);
+    void test_nn_2(bool symm1, bool symm2);
 
 };
 

--- a/tests/symmetry/so_dirprod_se_perm_test.C
+++ b/tests/symmetry/so_dirprod_se_perm_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void so_dirprod_se_perm_test::perform() throw(libtest::test_exception) {
+void so_dirprod_se_perm_test::perform() {
 
     test_empty_1();
     test_empty_2(true);
@@ -27,7 +27,7 @@ void so_dirprod_se_perm_test::perform() throw(libtest::test_exception) {
 /** \test Tests that the direct product of two empty group yields an empty
         group of a higher order
  **/
-void so_dirprod_se_perm_test::test_empty_1() throw(libtest::test_exception) {
+void so_dirprod_se_perm_test::test_empty_1() {
 
     static const char *testname =
             "so_dirprod_se_perm_test::test_empty_1()";
@@ -75,7 +75,7 @@ void so_dirprod_se_perm_test::test_empty_1() throw(libtest::test_exception) {
         a single element.
  **/
 void so_dirprod_se_perm_test::test_empty_2(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_perm_test::test_empty_2(" << perm << ")";
@@ -153,7 +153,7 @@ void so_dirprod_se_perm_test::test_empty_2(
         contain a single element.
  **/
 void so_dirprod_se_perm_test::test_empty_3(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_perm_test::test_empty_3(" << perm << ")";
@@ -232,7 +232,7 @@ void so_dirprod_se_perm_test::test_empty_3(
         a 5-space.
  **/
 void so_dirprod_se_perm_test::test_nn_1(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_perm_test::test_nn_1(" << symm1 << ", "
@@ -293,7 +293,7 @@ void so_dirprod_se_perm_test::test_nn_1(
         a 5-space. The result is permuted with [01234->13204].
  **/
 void so_dirprod_se_perm_test::test_nn_2(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_se_perm_test::test_nn_2(" << symm1 << ", "

--- a/tests/symmetry/so_dirprod_se_perm_test.h
+++ b/tests/symmetry/so_dirprod_se_perm_test.h
@@ -13,14 +13,14 @@ namespace libtensor {
  **/
 class so_dirprod_se_perm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2(bool perm) throw(libtest::test_exception);
-    void test_empty_3(bool perm) throw(libtest::test_exception);
-    void test_nn_1(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_nn_2(bool symm1, bool symm2) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2(bool perm);
+    void test_empty_3(bool perm);
+    void test_nn_1(bool symm1, bool symm2);
+    void test_nn_2(bool symm1, bool symm2);
 
 };
 

--- a/tests/symmetry/so_dirprod_test.C
+++ b/tests/symmetry/so_dirprod_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void so_dirprod_test::perform() throw(libtest::test_exception) {
+void so_dirprod_test::perform() {
 
     test_empty_1();
     test_empty_2(true); test_empty_2(false);
@@ -30,7 +30,7 @@ void so_dirprod_test::perform() throw(libtest::test_exception) {
 /** \test Direct product of empty symmetry in 2-space and empty symmetry in
         1-space to form a 3-space. Expects empty symmetry in 3-space.
  **/
-void so_dirprod_test::test_empty_1() throw(libtest::test_exception) {
+void so_dirprod_test::test_empty_1() {
 
     static const char *testname = "so_dirprod_test::test_empty_1()";
 
@@ -76,7 +76,7 @@ void so_dirprod_test::test_empty_1() throw(libtest::test_exception) {
 /** \test Direct product of non-empty symmetry in 2-space and empty symmetry
         in 1-space to form a 3-space. Expects non-empty symmetry in 3-space.
  **/
-void so_dirprod_test::test_empty_2(bool s) throw(libtest::test_exception) {
+void so_dirprod_test::test_empty_2(bool s) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_test::test_empty_2(" << s << ")";
@@ -123,7 +123,7 @@ void so_dirprod_test::test_empty_2(bool s) throw(libtest::test_exception) {
 /** \test Direct product of empty symmetry in 1-space and non-empty symmetry in
         2-space to form a 3-space. Expects non-empty symmetry in 3-space.
  **/
-void so_dirprod_test::test_empty_3(bool s) throw(libtest::test_exception) {
+void so_dirprod_test::test_empty_3(bool s) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_test::test_empty_3(" << s << ")";
@@ -172,7 +172,7 @@ void so_dirprod_test::test_empty_3(bool s) throw(libtest::test_exception) {
         Expects S2 * S2 in 4-space.
  **/
 void so_dirprod_test::test_se_1(
-        bool s1, bool s2) throw(libtest::test_exception) {
+        bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_test::test_se_1(" << s1 << ", " << s2 << ")";
@@ -229,7 +229,7 @@ void so_dirprod_test::test_se_1(
         symmetry in 3-space to from a 5-space.
  **/
 void so_dirprod_test::test_se_2(
-        bool s1, bool s2) throw(libtest::test_exception) {
+        bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_test::test_se_2(" << s1 << ", " << s2 << ")";
@@ -349,7 +349,7 @@ void so_dirprod_test::test_se_2(
 /** \test Direct product of a label symmetry in 2-space and a label symmetry
         in 3-space to form a 5-space
  **/
-void so_dirprod_test::test_se_3() throw(libtest::test_exception) {
+void so_dirprod_test::test_se_3() {
 
     static const char *testname = "so_dirprod_test::test_se_3()";
 
@@ -364,7 +364,7 @@ void so_dirprod_test::test_se_3() throw(libtest::test_exception) {
 /** \test Direct product of a symmetry with all symmetry elements in 2-space
         and a symmetry with all symmetry elements in 3-space to form a 5-space.
  **/
-void so_dirprod_test::test_se_4() throw(libtest::test_exception) {
+void so_dirprod_test::test_se_4() {
 
     static const char *testname = "so_dirprod_test::test_se_4()";
 
@@ -380,7 +380,7 @@ void so_dirprod_test::test_se_4() throw(libtest::test_exception) {
         form a 5-space with a permutation [01234->03214].
  **/
 void so_dirprod_test::test_perm_1(
-        bool s1, bool s2) throw(libtest::test_exception) {
+        bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_test::test_perm_1(" << s1 << ", " << s2 << ")";
@@ -502,7 +502,7 @@ void so_dirprod_test::test_perm_1(
         form a 5-space with a permutation [01234->21304].
  **/
 void so_dirprod_test::test_perm_2(
-        bool s1, bool s2) throw(libtest::test_exception) {
+        bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_dirprod_test::test_perm_2(" << s1 << ", " << s2 << ")";
@@ -623,7 +623,7 @@ void so_dirprod_test::test_perm_2(
 /** \test Direct product of a symmetry in 3-space and a symmetry in 0-space
         to form a 3-space.
  **/
-void so_dirprod_test::test_vac_1() throw(libtest::test_exception) {
+void so_dirprod_test::test_vac_1() {
 
     static const char *testname = "so_dirprod_test::test_vac_1()";
 
@@ -661,7 +661,7 @@ void so_dirprod_test::test_vac_1() throw(libtest::test_exception) {
 /** \test Direct product of a symmetry in 0-space and a symmetry in 3-space
         to form a 3-space.
  **/
-void so_dirprod_test::test_vac_2() throw(libtest::test_exception) {
+void so_dirprod_test::test_vac_2() {
 
     static const char *testname = "so_dirprod_test::test_vac_2()";
 

--- a/tests/symmetry/so_dirprod_test.h
+++ b/tests/symmetry/so_dirprod_test.h
@@ -11,20 +11,20 @@ namespace libtensor {
 **/
 class so_dirprod_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2(bool s) throw(libtest::test_exception);
-    void test_empty_3(bool s) throw(libtest::test_exception);
-    void test_se_1(bool s1, bool s2) throw(libtest::test_exception);
-    void test_se_2(bool s1, bool s2) throw(libtest::test_exception);
-    void test_se_3() throw(libtest::test_exception);
-    void test_se_4() throw(libtest::test_exception);
-    void test_perm_1(bool s1, bool s2) throw(libtest::test_exception);
-    void test_perm_2(bool s1, bool s2) throw(libtest::test_exception);
-    void test_vac_1() throw(libtest::test_exception);
-    void test_vac_2() throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2(bool s);
+    void test_empty_3(bool s);
+    void test_se_1(bool s1, bool s2);
+    void test_se_2(bool s1, bool s2);
+    void test_se_3();
+    void test_se_4();
+    void test_perm_1(bool s1, bool s2);
+    void test_perm_2(bool s1, bool s2);
+    void test_vac_1();
+    void test_vac_2();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/so_dirsum_se_label_test.C
+++ b/tests/symmetry/so_dirsum_se_label_test.C
@@ -5,7 +5,7 @@
 
 namespace libtensor {
 
-void so_dirsum_se_label_test::perform() throw(libtest::test_exception) {
+void so_dirsum_se_label_test::perform() {
 
     static const char *testname = "so_dirsum_se_label_test::perform()";
 
@@ -36,7 +36,7 @@ void so_dirsum_se_label_test::perform() throw(libtest::test_exception) {
         group of a higher order
  **/
 void so_dirsum_se_label_test::test_empty_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_label_test::test_empty_1(" << table_id << ")";
@@ -78,7 +78,7 @@ void so_dirsum_se_label_test::test_empty_1(
         group (1-space) forming a 3-space.
  **/
 void so_dirsum_se_label_test::test_empty_2(const std::string &table_id,
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_label_test::test_empty_2("
@@ -148,7 +148,7 @@ void so_dirsum_se_label_test::test_empty_2(const std::string &table_id,
         in 2-space forming a 3-space.
  **/
 void so_dirsum_se_label_test::test_empty_3(const std::string &table_id,
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_label_test::test_empty_3("
@@ -219,7 +219,7 @@ void so_dirsum_se_label_test::test_empty_3(const std::string &table_id,
         with Eu symmetry in 2-space.
  **/
 void so_dirsum_se_label_test::test_nn_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_label_test::test_nn_1(" << table_id << ")";
@@ -325,7 +325,7 @@ void so_dirsum_se_label_test::test_nn_1(
         2-space with Au symmetry. The result is permuted with [012->120].
  **/
 void so_dirsum_se_label_test::test_nn_2(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_label_test::test_nn_2(" << table_id << ")";
@@ -428,7 +428,7 @@ void so_dirsum_se_label_test::test_nn_2(
 /** \test Direct sum of two groups in 2-space one with composite rule.
  **/
 void so_dirsum_se_label_test::test_nn_3(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_label_test::test_nn_3(" << table_id << ")";

--- a/tests/symmetry/so_dirsum_se_label_test.h
+++ b/tests/symmetry/so_dirsum_se_label_test.h
@@ -13,21 +13,21 @@ namespace libtensor {
  **/
 class so_dirsum_se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_empty_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_empty_2(const std::string &table_id,
-            bool perm) throw(libtest::test_exception);
+            bool perm);
     void test_empty_3(const std::string &table_id,
-            bool perm) throw(libtest::test_exception);
+            bool perm);
     void test_nn_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nn_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nn_3(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/so_dirsum_se_part_test.C
+++ b/tests/symmetry/so_dirsum_se_part_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void so_dirsum_se_part_test::perform() throw(libtest::test_exception) {
+void so_dirsum_se_part_test::perform() {
 
     test_empty_1();
     test_empty_2(true);
@@ -37,7 +37,7 @@ void so_dirsum_se_part_test::perform() throw(libtest::test_exception) {
 /** \test Tests that the direct sum of two empty group yields an empty
         group of a higher order
  **/
-void so_dirsum_se_part_test::test_empty_1() throw(libtest::test_exception) {
+void so_dirsum_se_part_test::test_empty_1() {
 
     static const char *testname =
             "so_dirsum_se_part_test::test_empty_1()";
@@ -84,7 +84,7 @@ void so_dirsum_se_part_test::test_empty_1() throw(libtest::test_exception) {
         group (1-space) forming a 3-space.
  **/
 void so_dirsum_se_part_test::test_empty_2(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_part_test::test_empty_2(" << perm << ")";
@@ -170,7 +170,7 @@ void so_dirsum_se_part_test::test_empty_2(
         in 2-space forming a 3-space.
  **/
 void so_dirsum_se_part_test::test_empty_3(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_part_test::test_empty_3(" << perm << ")";
@@ -253,7 +253,7 @@ void so_dirsum_se_part_test::test_empty_3(
 /** \test Direct sum of a group in 1-space and a group in 2-space.
  **/
 void so_dirsum_se_part_test::test_nn_1(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_part_test::test_nn_1(" << symm1 << ", "
@@ -351,7 +351,7 @@ void so_dirsum_se_part_test::test_nn_1(
         result is permuted with [012->120].
  **/
 void so_dirsum_se_part_test::test_nn_2(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_part_test::test_nn_2(" << symm1 << ", "
@@ -449,7 +449,7 @@ void so_dirsum_se_part_test::test_nn_2(
 /** \test Direct sum of two groups in 2-space.
  **/
 void so_dirsum_se_part_test::test_nn_3(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_part_test::test_nn_3(" << symm1 << ", "
@@ -550,7 +550,7 @@ void so_dirsum_se_part_test::test_nn_3(
 /** \test Direct sum of two groups in 2-space.
  **/
 void so_dirsum_se_part_test::test_nn_4(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_part_test::test_nn_4(" << symm1 << ", "
@@ -662,7 +662,7 @@ void so_dirsum_se_part_test::test_nn_4(
 /** \test Direct sum of two groups in 2-space.
  **/
 void so_dirsum_se_part_test::test_nn_5(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_part_test::test_nn_5(" << symm << ")";

--- a/tests/symmetry/so_dirsum_se_part_test.h
+++ b/tests/symmetry/so_dirsum_se_part_test.h
@@ -13,17 +13,17 @@ namespace libtensor {
  **/
 class so_dirsum_se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2(bool perm) throw(libtest::test_exception);
-    void test_empty_3(bool perm) throw(libtest::test_exception);
-    void test_nn_1(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_nn_2(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_nn_3(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_nn_4(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_nn_5(bool symm) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2(bool perm);
+    void test_empty_3(bool perm);
+    void test_nn_1(bool symm1, bool symm2);
+    void test_nn_2(bool symm1, bool symm2);
+    void test_nn_3(bool symm1, bool symm2);
+    void test_nn_4(bool symm1, bool symm2);
+    void test_nn_5(bool symm);
 
 };
 

--- a/tests/symmetry/so_dirsum_se_perm_test.C
+++ b/tests/symmetry/so_dirsum_se_perm_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void so_dirsum_se_perm_test::perform() throw(libtest::test_exception) {
+void so_dirsum_se_perm_test::perform() {
 
     test_empty_1();
     test_empty_2(true);
@@ -27,7 +27,7 @@ void so_dirsum_se_perm_test::perform() throw(libtest::test_exception) {
 /** \test Tests that the direct sum of two empty group yields an empty
         group of a higher order.
  **/
-void so_dirsum_se_perm_test::test_empty_1() throw(libtest::test_exception) {
+void so_dirsum_se_perm_test::test_empty_1() {
 
     static const char *testname =
             "so_dirsum_se_perm_test::test_empty_1()";
@@ -74,7 +74,7 @@ void so_dirsum_se_perm_test::test_empty_1() throw(libtest::test_exception) {
         containing a single element (+) or an empty group (-).
  **/
 void so_dirsum_se_perm_test::test_empty_2(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_perm_test::test_empty_2(" << perm << ")";
@@ -143,7 +143,7 @@ void so_dirsum_se_perm_test::test_empty_2(
         containing a single element (+) or an empty group (-).
  **/
 void so_dirsum_se_perm_test::test_empty_3(
-        bool perm) throw(libtest::test_exception) {
+        bool perm) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_perm_test::test_empty_3(" << perm << ")";
@@ -204,7 +204,7 @@ void so_dirsum_se_perm_test::test_empty_3(
         a 5-space.
  **/
 void so_dirsum_se_perm_test::test_nn_1(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_perm_test::test_nn_1(" << symm1 << ", "
@@ -271,7 +271,7 @@ void so_dirsum_se_perm_test::test_nn_1(
         a 5-space. The result is permuted with [01234->13204].
  **/
 void so_dirsum_se_perm_test::test_nn_2(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_se_perm_test::test_nn_2(" << symm1 << ", "

--- a/tests/symmetry/so_dirsum_se_perm_test.h
+++ b/tests/symmetry/so_dirsum_se_perm_test.h
@@ -13,14 +13,14 @@ namespace libtensor {
  **/
 class so_dirsum_se_perm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2(bool perm) throw(libtest::test_exception);
-    void test_empty_3(bool perm) throw(libtest::test_exception);
-    void test_nn_1(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_nn_2(bool symm1, bool symm2) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2(bool perm);
+    void test_empty_3(bool perm);
+    void test_nn_1(bool symm1, bool symm2);
+    void test_nn_2(bool symm1, bool symm2);
 
 };
 

--- a/tests/symmetry/so_dirsum_test.C
+++ b/tests/symmetry/so_dirsum_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void so_dirsum_test::perform() throw(libtest::test_exception) {
+void so_dirsum_test::perform() {
 
     test_empty_1();
     test_empty_2();
@@ -28,7 +28,7 @@ void so_dirsum_test::perform() throw(libtest::test_exception) {
 /** \test Direct product of empty symmetry in 2-space and empty symmetry in
         1-space to form a 3-space. Expects empty symmetry in 3-space.
  **/
-void so_dirsum_test::test_empty_1() throw(libtest::test_exception) {
+void so_dirsum_test::test_empty_1() {
 
     static const char *testname = "so_dirsum_test::test_empty_1()";
 
@@ -74,7 +74,7 @@ void so_dirsum_test::test_empty_1() throw(libtest::test_exception) {
 /** \test Direct product of non-empty symmetry in 2-space and empty symmetry
         in 1-space to form a 3-space. Expects non-empty symmetry in 3-space.
  **/
-void so_dirsum_test::test_empty_2() throw(libtest::test_exception) {
+void so_dirsum_test::test_empty_2() {
 
     static const char *testname = "so_dirsum_test::test_empty_2()";
 
@@ -83,7 +83,7 @@ void so_dirsum_test::test_empty_2() throw(libtest::test_exception) {
 /** \test Direct product of empty symmetry in 1-space and non-empty symmetry in
         2-space to form a 3-space. Expects non-empty symmetry in 3-space.
  **/
-void so_dirsum_test::test_empty_3() throw(libtest::test_exception) {
+void so_dirsum_test::test_empty_3() {
 
     static const char *testname = "so_dirsum_test::test_empty_3()";
 
@@ -93,7 +93,7 @@ void so_dirsum_test::test_empty_3() throw(libtest::test_exception) {
         Expects S2*S2 in 4-space.
  **/
 void so_dirsum_test::test_se_1(bool s1,
-        bool s2) throw(libtest::test_exception) {
+        bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_test::test_se_1(" << s1 << ", " << s2 << ")";
@@ -158,7 +158,7 @@ void so_dirsum_test::test_se_1(bool s1,
         symmetry in 2-space to from a 2-space.
  **/
 void so_dirsum_test::test_se_2(bool s1,
-        bool s2) throw(libtest::test_exception) {
+        bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_dirsum_test::test_se_2(" << s1 << ", " << s2 << ")";
@@ -271,7 +271,7 @@ void so_dirsum_test::test_se_2(bool s1,
 /** \test Direct product of a label symmetry in 3-space and a label symmetry
         in 3-space to form a 5-space
  **/
-void so_dirsum_test::test_se_3() throw(libtest::test_exception) {
+void so_dirsum_test::test_se_3() {
 
     static const char *testname = "so_dirsum_test::test_se_3()";
 
@@ -286,7 +286,7 @@ void so_dirsum_test::test_se_3() throw(libtest::test_exception) {
 /** \test Direct product of a symmetry with all symmetry elements in 2-space
         and a symmetry with all symmetry elements in 3-space to form a 5-space.
  **/
-void so_dirsum_test::test_se_4() throw(libtest::test_exception) {
+void so_dirsum_test::test_se_4() {
 
     static const char *testname = "so_dirsum_test::test_se_4()";
 
@@ -301,7 +301,7 @@ void so_dirsum_test::test_se_4() throw(libtest::test_exception) {
 /** \test Direct product of a symmetry in 2-space and a symmetry in 3-space
         form a 5-space with a permutation [01234->03214].
  **/
-void so_dirsum_test::test_perm_1() throw(libtest::test_exception) {
+void so_dirsum_test::test_perm_1() {
 
     static const char *testname = "so_dirsum_test::test_perm_1()";
 
@@ -316,7 +316,7 @@ void so_dirsum_test::test_perm_1() throw(libtest::test_exception) {
 /** \test Direct product of a symmetry in 3-space and a symmetry in 2-space
         form a 5-space with a permutation [01234->21304].
  **/
-void so_dirsum_test::test_perm_2() throw(libtest::test_exception) {
+void so_dirsum_test::test_perm_2() {
 
     static const char *testname = "so_dirsum_test::test_perm_2()";
 
@@ -331,7 +331,7 @@ void so_dirsum_test::test_perm_2() throw(libtest::test_exception) {
 /** \test Direct product of a symmetry in 3-space and a symmetry in 0-space
         to form a 3-space.
  **/
-void so_dirsum_test::test_vac_1() throw(libtest::test_exception) {
+void so_dirsum_test::test_vac_1() {
 
     static const char *testname = "so_dirsum_test::test_vac_1()";
 
@@ -369,7 +369,7 @@ void so_dirsum_test::test_vac_1() throw(libtest::test_exception) {
 /** \test Direct product of a symmetry in 0-space and a symmetry in 3-space
         to form a 3-space.
  **/
-void so_dirsum_test::test_vac_2() throw(libtest::test_exception) {
+void so_dirsum_test::test_vac_2() {
 
     static const char *testname = "so_dirsum_test::test_vac_2()";
 

--- a/tests/symmetry/so_dirsum_test.h
+++ b/tests/symmetry/so_dirsum_test.h
@@ -11,20 +11,20 @@ namespace libtensor {
 **/
 class so_dirsum_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2() throw(libtest::test_exception);
-    void test_empty_3() throw(libtest::test_exception);
-    void test_se_1(bool s1, bool s2) throw(libtest::test_exception);
-    void test_se_2(bool s1, bool s2) throw(libtest::test_exception);
-    void test_se_3() throw(libtest::test_exception);
-    void test_se_4() throw(libtest::test_exception);
-    void test_perm_1() throw(libtest::test_exception);
-    void test_perm_2() throw(libtest::test_exception);
-    void test_vac_1() throw(libtest::test_exception);
-    void test_vac_2() throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2();
+    void test_empty_3();
+    void test_se_1(bool s1, bool s2);
+    void test_se_2(bool s1, bool s2);
+    void test_se_3();
+    void test_se_4();
+    void test_perm_1();
+    void test_perm_2();
+    void test_vac_1();
+    void test_vac_2();
 };
 
 } // namespace libtensor

--- a/tests/symmetry/so_merge_se_label_test.C
+++ b/tests/symmetry/so_merge_se_label_test.C
@@ -4,7 +4,7 @@
 
 namespace libtensor {
 
-void so_merge_se_label_test::perform() throw(libtest::test_exception) {
+void so_merge_se_label_test::perform() {
 
     std::string table_id = "S6";
     setup_pg_table(table_id);
@@ -36,7 +36,7 @@ void so_merge_se_label_test::perform() throw(libtest::test_exception) {
         empty group of lower order
  **/
 void so_merge_se_label_test::test_empty_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_empty_1(" << table_id << ")";
@@ -65,7 +65,7 @@ void so_merge_se_label_test::test_empty_1(
         yields an empty group of lower order
  **/
 void so_merge_se_label_test::test_empty_2(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_empty_2(" << table_id << ")";
@@ -94,7 +94,7 @@ void so_merge_se_label_test::test_empty_2(
 /** \test Merge of 2 dim of a 3-space on a 1-space in one step.
  **/
 void so_merge_se_label_test::test_nm1_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_nm1_1(" << table_id << ")";
@@ -163,7 +163,7 @@ void so_merge_se_label_test::test_nm1_1(
 /** \test Single merge of 3 dim of a 3-space on a 1-space.
  **/
 void so_merge_se_label_test::test_nm1_2(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_nm1_2(" << table_id << ")";
@@ -220,7 +220,7 @@ void so_merge_se_label_test::test_nm1_2(
 /** \test Double merge of 4 dim of a 4-space on a 2-space (simple rule)
  **/
 void so_merge_se_label_test::test_2n2nn_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_2n2nn_1(" << table_id << ")";
@@ -277,7 +277,7 @@ void so_merge_se_label_test::test_2n2nn_1(
 /** \test Double merge of 4 dim of a 4-space on a 2-space (complex rule)
  **/
 void so_merge_se_label_test::test_2n2nn_2(const std::string &table_id,
-        bool product) throw(libtest::test_exception) {
+        bool product) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_2n2nn_2("
@@ -348,7 +348,7 @@ void so_merge_se_label_test::test_2n2nn_2(const std::string &table_id,
 /** \test Double merge of 4 dim of a 5-space on a 3-space.
  **/
 void so_merge_se_label_test::test_nmk_1(const std::string &table_id,
-        bool product) throw(libtest::test_exception) {
+        bool product) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_nmk_1("
@@ -435,7 +435,7 @@ void so_merge_se_label_test::test_nmk_1(const std::string &table_id,
 /** \test Double merge of 4 dim of a 5-space on a 3-space.
  **/
 void so_merge_se_label_test::test_nmk_2(const std::string &table_id,
-        bool product) throw(libtest::test_exception) {
+        bool product) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_label_test::test_nmk_2("

--- a/tests/symmetry/so_merge_se_label_test.h
+++ b/tests/symmetry/so_merge_se_label_test.h
@@ -11,25 +11,25 @@ namespace libtensor {
  **/
 class so_merge_se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_empty_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_empty_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nm1_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nm1_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_2n2nn_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_2n2nn_2(const std::string &table_id,
-            bool product) throw(libtest::test_exception);
+            bool product);
     void test_nmk_1(const std::string &table_id,
-            bool product) throw(libtest::test_exception);
+            bool product);
     void test_nmk_2(const std::string &table_id,
-            bool product) throw(libtest::test_exception);
+            bool product);
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/so_merge_se_part_test.C
+++ b/tests/symmetry/so_merge_se_part_test.C
@@ -6,7 +6,7 @@
 
 namespace libtensor {
 
-void so_merge_se_part_test::perform() throw(libtest::test_exception) {
+void so_merge_se_part_test::perform() {
 
     test_empty_1();
     test_empty_2();
@@ -26,7 +26,7 @@ void so_merge_se_part_test::perform() throw(libtest::test_exception) {
 /** \test Tests that a single merge of 2 dim of an empty partition set yields
         an empty partition set of lower order
  **/
-void so_merge_se_part_test::test_empty_1() throw(libtest::test_exception) {
+void so_merge_se_part_test::test_empty_1() {
 
     static const char *testname = "so_merge_se_part_test::test_empty_1()";
 
@@ -60,7 +60,7 @@ void so_merge_se_part_test::test_empty_1() throw(libtest::test_exception) {
 /** \test Tests that a double merge of dimensions of an empty partition set
         yields an empty partition set of lower order
  **/
-void so_merge_se_part_test::test_empty_2() throw(libtest::test_exception) {
+void so_merge_se_part_test::test_empty_2() {
 
     static const char *testname = "so_merge_se_part_test::test_empty_2()";
 

--- a/tests/symmetry/so_merge_se_part_test.C
+++ b/tests/symmetry/so_merge_se_part_test.C
@@ -93,8 +93,7 @@ void so_merge_se_part_test::test_empty_2() {
 
 /** \test Single merge of 2 dim of a 3-space on a 2-space.
  **/
-void so_merge_se_part_test::test_nm1_1(bool sign)
-throw(libtest::test_exception) {
+void so_merge_se_part_test::test_nm1_1(bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_part_test::test_nm1_1(" << sign << ")";
@@ -175,8 +174,7 @@ throw(libtest::test_exception) {
 
 /** \test Single merge of 3 dim of a 3-space on a 1-space.
  **/
-void so_merge_se_part_test::test_nm1_2(bool sign)
-throw(libtest::test_exception) {
+void so_merge_se_part_test::test_nm1_2(bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_part_test::test_nm1_1(" << tnss << ")";
@@ -253,8 +251,7 @@ throw(libtest::test_exception) {
 
 /** \test Double merge of 4 dim of a 4-space on a 2-space.
  **/
-void so_merge_se_part_test::test_2n2nn_1(bool s1, bool s2)
-throw(libtest::test_exception) {
+void so_merge_se_part_test::test_2n2nn_1(bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_part_test::test_2n2nn_1(" << s1 << ", " << s2 << ")";
@@ -345,8 +342,7 @@ throw(libtest::test_exception) {
 
 /** \test Double merge of 4 dim of a 4-space on a 2-space.
  **/
-void so_merge_se_part_test::test_2n2nn_2(bool s1, bool s2)
-throw(libtest::test_exception) {
+void so_merge_se_part_test::test_2n2nn_2(bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_part_test::test_2n2nn_2(" << s1 << ", " << s2 << ")";
@@ -446,8 +442,7 @@ throw(libtest::test_exception) {
 
 /** \test Double merge of 4 dim of a 4-space on a 2-space.
  **/
-void so_merge_se_part_test::test_2n2nn_3(bool sign)
-throw(libtest::test_exception) {
+void so_merge_se_part_test::test_2n2nn_3(bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_part_test::test_2n2nn_3(" << sign << ")";
@@ -520,8 +515,7 @@ throw(libtest::test_exception) {
 
 /** \test Double merge of 4 dim of a 5-space on a 3-space.
  **/
-void so_merge_se_part_test::test_nmk_1(bool sign)
-throw(libtest::test_exception) {
+void so_merge_se_part_test::test_nmk_1(bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_part_test::test_nmk_1(" << sign << ")";
@@ -653,8 +647,7 @@ throw(libtest::test_exception) {
     - Forbidden partitions: \c 001, \c 010, \c 100, \c 111
 
  **/
-void so_merge_se_part_test::test_nmk_2(bool s1, bool s2)
-throw(libtest::test_exception) {
+void so_merge_se_part_test::test_nmk_2(bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_part_test::test_nmk_2(" << s1 << ", " << s2 << ")";

--- a/tests/symmetry/so_merge_se_part_test.h
+++ b/tests/symmetry/so_merge_se_part_test.h
@@ -12,18 +12,18 @@ namespace libtensor {
  **/
 class so_merge_se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2() throw(libtest::test_exception);
-    void test_nm1_1(bool sign) throw(libtest::test_exception);
-    void test_nm1_2(bool sign) throw(libtest::test_exception);
-    void test_2n2nn_1(bool s1, bool s2) throw(libtest::test_exception);
-    void test_2n2nn_2(bool s1, bool s2) throw(libtest::test_exception);
-    void test_2n2nn_3(bool sign) throw(libtest::test_exception);
-    void test_nmk_1(bool sign) throw(libtest::test_exception);
-    void test_nmk_2(bool s1, bool s2) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2();
+    void test_nm1_1(bool sign);
+    void test_nm1_2(bool sign);
+    void test_2n2nn_1(bool s1, bool s2);
+    void test_2n2nn_2(bool s1, bool s2);
+    void test_2n2nn_3(bool sign);
+    void test_nmk_1(bool sign);
+    void test_nmk_2(bool s1, bool s2);
 
 };
 

--- a/tests/symmetry/so_merge_se_perm_test.C
+++ b/tests/symmetry/so_merge_se_perm_test.C
@@ -6,7 +6,7 @@
 namespace libtensor {
 
 
-void so_merge_se_perm_test::perform() throw(libtest::test_exception) {
+void so_merge_se_perm_test::perform() {
 
     test_empty_1();
     test_empty_2();
@@ -26,7 +26,7 @@ void so_merge_se_perm_test::perform() throw(libtest::test_exception) {
 /** \test Tests that a merge of 2 dims of an empty group yields an empty group
         of a lower order
  **/
-void so_merge_se_perm_test::test_empty_1() throw(libtest::test_exception) {
+void so_merge_se_perm_test::test_empty_1() {
 
     static const char *testname = "so_merge_se_perm_test::test_empty_1()";
 
@@ -60,7 +60,7 @@ void so_merge_se_perm_test::test_empty_1() throw(libtest::test_exception) {
 /** \test Tests that a merge of all dims of an empty group yields an empty
         group of dim 1
  **/
-void so_merge_se_perm_test::test_empty_2() throw(libtest::test_exception) {
+void so_merge_se_perm_test::test_empty_2() {
 
     static const char *testname = "so_merge_se_perm_test::test_empty_2()";
 
@@ -94,7 +94,7 @@ void so_merge_se_perm_test::test_empty_2() throw(libtest::test_exception) {
 /** \test Tests that multiple merges of 2 dims of an empty group yield an
         empty group of lower order
  **/
-void so_merge_se_perm_test::test_empty_3() throw(libtest::test_exception) {
+void so_merge_se_perm_test::test_empty_3() {
 
     static const char *testname = "so_merge_se_perm_test::test_empty_3()";
 
@@ -129,7 +129,7 @@ void so_merge_se_perm_test::test_empty_3() throw(libtest::test_exception) {
         result: C1 in 1-space. Symmetric elements.
  **/
 void so_merge_se_perm_test::test_nn1(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_nn1(" << symm << ")";
@@ -188,7 +188,7 @@ void so_merge_se_perm_test::test_nn1(
         the masks. Expected result: 2-cycle in 3-space.
  **/
 void so_merge_se_perm_test::test_nm1_1(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_nm1_1(" << symm << ")";
@@ -249,7 +249,7 @@ void so_merge_se_perm_test::test_nm1_1(
         dimension out. Expected result: C1 in 4-space.
  **/
 void so_merge_se_perm_test::test_nm1_2(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_nm1_2(" << symm << ")";
@@ -291,7 +291,7 @@ void so_merge_se_perm_test::test_nm1_2(
 /** \test Merge of 2 dim of a group in a 4-space onto a 3-space.
  **/
 void so_merge_se_perm_test::test_nm1_3(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_nm1_3(" << symm << ")";
@@ -352,7 +352,7 @@ void so_merge_se_perm_test::test_nm1_3(
 /** \test Double merge of a group in a 4-space onto a 2-space.
  **/
 void so_merge_se_perm_test::test_2n2nn_1(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_2n2nn_1(" <<
@@ -415,7 +415,7 @@ void so_merge_se_perm_test::test_2n2nn_1(
 /** \test Double merge of a group in a 4-space onto a 2-space.
  **/
 void so_merge_se_perm_test::test_2n2nn_2(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_2n2nn_1(" << symm << ")";
@@ -474,7 +474,7 @@ void so_merge_se_perm_test::test_2n2nn_2(
 /** \test Double merge of a group in a 6-space onto 4-space.
  **/
 void so_merge_se_perm_test::test_nmk_1(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_nmk_1(" << symm << ")";
@@ -539,7 +539,7 @@ void so_merge_se_perm_test::test_nmk_1(
 /** \test Triple merge of a group in a 8-space onto 4-space.
  **/
 void so_merge_se_perm_test::test_nmk_2(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_merge_se_perm_test::test_nmk_2(" << symm << ")";

--- a/tests/symmetry/so_merge_se_perm_test.h
+++ b/tests/symmetry/so_merge_se_perm_test.h
@@ -12,20 +12,20 @@ namespace libtensor {
  **/
 class so_merge_se_perm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2() throw(libtest::test_exception);
-    void test_empty_3() throw(libtest::test_exception);
-    void test_nn1(bool symm) throw(libtest::test_exception);
-    void test_nm1_1(bool symm) throw(libtest::test_exception);
-    void test_nm1_2(bool symm) throw(libtest::test_exception);
-    void test_nm1_3(bool symm) throw(libtest::test_exception);
-    void test_2n2nn_1(bool symm1, bool symm2) throw(libtest::test_exception);
-    void test_2n2nn_2(bool symm) throw(libtest::test_exception);
-    void test_nmk_1(bool symm) throw(libtest::test_exception);
-    void test_nmk_2(bool symm) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2();
+    void test_empty_3();
+    void test_nn1(bool symm);
+    void test_nm1_1(bool symm);
+    void test_nm1_2(bool symm);
+    void test_nm1_3(bool symm);
+    void test_2n2nn_1(bool symm1, bool symm2);
+    void test_2n2nn_2(bool symm);
+    void test_nmk_1(bool symm);
+    void test_nmk_2(bool symm);
 };
 
 

--- a/tests/symmetry/so_merge_test.C
+++ b/tests/symmetry/so_merge_test.C
@@ -10,7 +10,7 @@
 namespace libtensor {
 
 
-void so_merge_test::perform() throw(libtest::test_exception) {
+void so_merge_test::perform() {
 
     setup_pg_table("cs");
 
@@ -34,7 +34,7 @@ void so_merge_test::perform() throw(libtest::test_exception) {
 /** \test Invokes merge of 2 dimensions of C1 in 4-space onto 3-space.
         Expects C1 in 3-space.
  **/
-void so_merge_test::test_1() throw(libtest::test_exception) {
+void so_merge_test::test_1() {
 
     static const char *testname = "so_merge_test::test_1()";
 
@@ -70,7 +70,7 @@ void so_merge_test::test_1() throw(libtest::test_exception) {
 /** \test Invokes a merge of 3 dim in S5(+) in 5-space onto 3-space.
         Expects S3(+) in 3-space.
  **/
-void so_merge_test::test_2() throw(libtest::test_exception) {
+void so_merge_test::test_2() {
 
     static const char *testname = "so_merge_test::test_2()";
 
@@ -118,7 +118,7 @@ void so_merge_test::test_2() throw(libtest::test_exception) {
 
 /** \test Invokes merge of 2 dims of S2(+) onto 1-space.
  **/
-void so_merge_test::test_3() throw(libtest::test_exception) {
+void so_merge_test::test_3() {
 
     static const char *testname = "so_merge_test::test_3()";
 
@@ -146,7 +146,7 @@ void so_merge_test::test_3() throw(libtest::test_exception) {
 
 /** \test Invokes a projection of S2(+) onto 2-space.
  **/
-void so_merge_test::test_4() throw(libtest::test_exception) {
+void so_merge_test::test_4() {
 
     static const char *testname = "so_merge_test::test_4()";
 
@@ -178,7 +178,7 @@ void so_merge_test::test_4() throw(libtest::test_exception) {
 
 /** \test Computes the symmetry of the sum of two tensors
  **/
-void so_merge_test::test_5() throw(libtest::test_exception) {
+void so_merge_test::test_5() {
 
     static const char *testname = "so_merge_test::test_5()";
 

--- a/tests/symmetry/so_merge_test.h
+++ b/tests/symmetry/so_merge_test.h
@@ -11,14 +11,14 @@ namespace libtensor {
 **/
 class so_merge_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
 
 };
 

--- a/tests/symmetry/so_permute_se_label_test.C
+++ b/tests/symmetry/so_permute_se_label_test.C
@@ -6,7 +6,7 @@
 
 namespace libtensor {
 
-void so_permute_se_label_test::perform() throw(libtest::test_exception) {
+void so_permute_se_label_test::perform() {
 
     std::string s6 = "S6";
     setup_pg_table(s6);
@@ -28,7 +28,7 @@ void so_permute_se_label_test::perform() throw(libtest::test_exception) {
 /** \test Permutes a group with one element of Au symmetry.
  **/
 void so_permute_se_label_test::test_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_permute_se_label_test::test_1(" << table_id << ")";

--- a/tests/symmetry/so_permute_se_label_test.h
+++ b/tests/symmetry/so_permute_se_label_test.h
@@ -13,10 +13,10 @@ namespace libtensor {
  **/
 class so_permute_se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1(const std::string &table_id) throw(libtest::test_exception);
+    void test_1(const std::string &table_id);
 
     using se_label_test_base::check_allowed;
     using se_label_test_base::setup_pg_table;

--- a/tests/symmetry/so_permute_se_part_test.C
+++ b/tests/symmetry/so_permute_se_part_test.C
@@ -5,7 +5,7 @@
 
 namespace libtensor {
 
-void so_permute_se_part_test::perform() throw(libtest::test_exception) {
+void so_permute_se_part_test::perform() {
 
     test_1();
     test_2a();
@@ -17,7 +17,7 @@ void so_permute_se_part_test::perform() throw(libtest::test_exception) {
 
 /** \test Tests permutation of an empty set
  **/
-void so_permute_se_part_test::test_1() throw(libtest::test_exception) {
+void so_permute_se_part_test::test_1() {
 
     static const char *testname = "so_permute_se_part_test::test_1()";
 
@@ -67,7 +67,7 @@ void so_permute_se_part_test::test_1() throw(libtest::test_exception) {
 /** \test Tests permutation of a non-empty set. Permutation does not affect
         the mapping
  **/
-void so_permute_se_part_test::test_2a() throw(libtest::test_exception) {
+void so_permute_se_part_test::test_2a() {
 
     static const char *testname = "so_permute_se_part_test::test_2a()";
 
@@ -137,7 +137,7 @@ void so_permute_se_part_test::test_2a() throw(libtest::test_exception) {
 /** \test Tests permutation of a non-empty set. Permutation does not affect
         the mapping
  **/
-void so_permute_se_part_test::test_2b() throw(libtest::test_exception) {
+void so_permute_se_part_test::test_2b() {
 
     static const char *testname = "so_permute_se_part_test::test_2b()";
 
@@ -207,7 +207,7 @@ void so_permute_se_part_test::test_2b() throw(libtest::test_exception) {
 
 /** \test Tests permutation of a non-empty set.
  **/
-void so_permute_se_part_test::test_3() throw(libtest::test_exception) {
+void so_permute_se_part_test::test_3() {
 
     static const char *testname = "so_permute_se_part_test::test_3()";
 

--- a/tests/symmetry/so_permute_se_part_test.h
+++ b/tests/symmetry/so_permute_se_part_test.h
@@ -12,13 +12,13 @@ namespace libtensor {
  **/
 class so_permute_se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2a() throw(libtest::test_exception);
-    void test_2b() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
+    void test_1();
+    void test_2a();
+    void test_2b();
+    void test_3();
 
 };
 

--- a/tests/symmetry/so_permute_se_perm_test.C
+++ b/tests/symmetry/so_permute_se_perm_test.C
@@ -5,7 +5,7 @@
 
 namespace libtensor {
 
-void so_permute_se_perm_test::perform() throw(libtest::test_exception) {
+void so_permute_se_perm_test::perform() {
 
     test_1();
 
@@ -14,7 +14,7 @@ void so_permute_se_perm_test::perform() throw(libtest::test_exception) {
 
 /** \test Permutes a group with one element of Au symmetry.
  **/
-void so_permute_se_perm_test::test_1() throw(libtest::test_exception) {
+void so_permute_se_perm_test::test_1() {
 
     static const char *testname = "so_permute_se_perm_test::test_1()";
 

--- a/tests/symmetry/so_permute_se_perm_test.h
+++ b/tests/symmetry/so_permute_se_perm_test.h
@@ -12,10 +12,10 @@ namespace libtensor {
  **/
 class so_permute_se_perm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
+    void test_1();
 
 };
 

--- a/tests/symmetry/so_reduce_se_label_test.C
+++ b/tests/symmetry/so_reduce_se_label_test.C
@@ -4,7 +4,7 @@
 
 namespace libtensor {
 
-void so_reduce_se_label_test::perform() throw(libtest::test_exception) {
+void so_reduce_se_label_test::perform() {
 
     std::string id1 = "S6", id2 = "C2v";
     setup_pg_table(id1);
@@ -46,7 +46,7 @@ void so_reduce_se_label_test::perform() throw(libtest::test_exception) {
         empty group of lower order
  **/
 void so_reduce_se_label_test::test_empty_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_empty_1(" << table_id << ")";
@@ -77,7 +77,7 @@ void so_reduce_se_label_test::test_empty_1(
         yields an empty group of lower order
  **/
 void so_reduce_se_label_test::test_empty_2(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_empty_2(" << table_id << ")";
@@ -108,7 +108,7 @@ void so_reduce_se_label_test::test_empty_2(
 /** \test Reduction of 2 dim of a 3-space on a 1-space in one step.
  **/
 void so_reduce_se_label_test::test_nm1_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nm1_1(" << table_id << ")";
@@ -168,7 +168,7 @@ void so_reduce_se_label_test::test_nm1_1(
 /** \test Single reduction of 2 dim of a 4-space on a 2-space.
  **/
 void so_reduce_se_label_test::test_nm1_2(const std::string &table_id,
-        bool product) throw(libtest::test_exception) {
+        bool product) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nm1_2(" <<
@@ -245,7 +245,7 @@ void so_reduce_se_label_test::test_nm1_2(const std::string &table_id,
         dimensions).
  **/
 void so_reduce_se_label_test::test_nm1_3(const std::string &table_id,
-        bool product) throw(libtest::test_exception) {
+        bool product) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nm1_3(" <<
@@ -315,7 +315,7 @@ void so_reduce_se_label_test::test_nm1_3(const std::string &table_id,
 /** \test Single reduction of 2 dim of a 6-space on a 4-space.
  **/
 void so_reduce_se_label_test::test_nm1_4(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nm1_4(" <<
@@ -402,7 +402,7 @@ void so_reduce_se_label_test::test_nm1_4(
         term being all-allowed.
  **/
 void so_reduce_se_label_test::test_nm1_5(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nm1_5(" << table_id << ")";
@@ -463,7 +463,7 @@ void so_reduce_se_label_test::test_nm1_5(
 }
 
 
-void so_reduce_se_label_test::test_nm1_6() throw(libtest::test_exception) {
+void so_reduce_se_label_test::test_nm1_6() {
 
     const char testname[] = "so_reduce_se_label_test::test_nm1_6()";
 
@@ -542,7 +542,7 @@ void so_reduce_se_label_test::test_nm1_6() throw(libtest::test_exception) {
 
 /** \test Simple reduction of 2 dim of a 4-space on a 2-space
  **/
-void so_reduce_se_label_test::test_nm1_7() throw(libtest::test_exception) {
+void so_reduce_se_label_test::test_nm1_7() {
 
 	const char testname[] = "so_reduce_se_label_test::test_nm1_7()";
 
@@ -620,7 +620,7 @@ void so_reduce_se_label_test::test_nm1_7() throw(libtest::test_exception) {
 /** \test Double reduction of 4 dim of a 6-space on a 2-space (simple rule)
  **/
 void so_reduce_se_label_test::test_nmk_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nmk_1(" << table_id << ")";
@@ -681,7 +681,7 @@ void so_reduce_se_label_test::test_nmk_1(
 /** \test Double reduction of 4 dim of a 6-space on a 2-space (complex rule)
  **/
 void so_reduce_se_label_test::test_nmk_2(const std::string &table_id,
-        bool product) throw(libtest::test_exception) {
+        bool product) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nmk_2("
@@ -760,7 +760,7 @@ void so_reduce_se_label_test::test_nmk_2(const std::string &table_id,
 /** \test Triple reduction of 3 dim of a 6-space on a 3-space
  **/
 void so_reduce_se_label_test::test_nmk_3(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nmk_3("
@@ -822,7 +822,7 @@ void so_reduce_se_label_test::test_nmk_3(
 
 /** \test Double reduction of 3 dim of a 6-space on a 3-space
  **/
-void so_reduce_se_label_test::test_nmk_4() throw(libtest::test_exception) {
+void so_reduce_se_label_test::test_nmk_4() {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_label_test::test_nmk_4()";

--- a/tests/symmetry/so_reduce_se_label_test.h
+++ b/tests/symmetry/so_reduce_se_label_test.h
@@ -11,32 +11,32 @@ namespace libtensor {
  **/
 class so_reduce_se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_empty_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_empty_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nm1_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nm1_2(const std::string &table_id,
-            bool product) throw(libtest::test_exception);
+            bool product);
     void test_nm1_3(const std::string &table_id,
-            bool product) throw(libtest::test_exception);
+            bool product);
     void test_nm1_4(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nm1_5(
-            const std::string &table_id) throw(libtest::test_exception);
-    void test_nm1_6() throw(libtest::test_exception);
-    void test_nm1_7() throw(libtest::test_exception);
+            const std::string &table_id);
+    void test_nm1_6();
+    void test_nm1_7();
     void test_nmk_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_nmk_2(const std::string &table_id,
-            bool product) throw(libtest::test_exception);
+            bool product);
     void test_nmk_3(
-            const std::string &table_id) throw(libtest::test_exception);
-    void test_nmk_4() throw(libtest::test_exception);
+            const std::string &table_id);
+    void test_nmk_4();
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/so_reduce_se_part_test.C
+++ b/tests/symmetry/so_reduce_se_part_test.C
@@ -99,8 +99,7 @@ void so_reduce_se_part_test::test_empty_2() {
 
 /** \test Projection of a 2-space in a single reduction step on a 1-space.
  **/
-void so_reduce_se_part_test::test_nm1_1(bool sign)
-throw(libtest::test_exception) {
+void so_reduce_se_part_test::test_nm1_1(bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nm1_1(" << sign << ")";

--- a/tests/symmetry/so_reduce_se_part_test.C
+++ b/tests/symmetry/so_reduce_se_part_test.C
@@ -6,7 +6,7 @@
 
 namespace libtensor {
 
-void so_reduce_se_part_test::perform() throw(libtest::test_exception) {
+void so_reduce_se_part_test::perform() {
 
     test_empty_1();
     test_empty_2();
@@ -28,7 +28,7 @@ void so_reduce_se_part_test::perform() throw(libtest::test_exception) {
 /** \test Tests that a projection of an empty group yields an empty group
         of a lower order
  **/
-void so_reduce_se_part_test::test_empty_1() throw(libtest::test_exception) {
+void so_reduce_se_part_test::test_empty_1() {
 
     static const char *testname = "so_reduce_se_part_test::test_empty_1()";
 
@@ -64,7 +64,7 @@ void so_reduce_se_part_test::test_empty_1() throw(libtest::test_exception) {
 /** \test Tests that a double projection of an empty group yields an empty group
         of a lower order
  **/
-void so_reduce_se_part_test::test_empty_2() throw(libtest::test_exception) {
+void so_reduce_se_part_test::test_empty_2() {
 
     static const char *testname = "so_reduce_se_part_test::test_empty_2()";
 
@@ -177,7 +177,7 @@ throw(libtest::test_exception) {
 /** \test Projection of a 4-space in one reduction step onto a 2-space.
  **/
 void so_reduce_se_part_test::test_nm1_2(
-        bool s1, bool s2) throw(libtest::test_exception) {
+        bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nm1_2(" << s1 << ", " << s2 << ")";
@@ -277,7 +277,7 @@ void so_reduce_se_part_test::test_nm1_2(
 
  **/
 void so_reduce_se_part_test::test_nm1_3(
-        bool sign) throw(libtest::test_exception) {
+        bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nm1_3("")";
@@ -361,7 +361,7 @@ void so_reduce_se_part_test::test_nm1_3(
         partitioning (only one partitioned dim, not projected)
  **/
 void so_reduce_se_part_test::test_nm1_4(
-        bool sign) throw(libtest::test_exception) {
+        bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nm1_4(" << sign << ")";
@@ -446,7 +446,7 @@ void so_reduce_se_part_test::test_nm1_4(
         partitioning (only one partitioned dim, projected)
  **/
 void so_reduce_se_part_test::test_nm1_5(
-        bool sign) throw(libtest::test_exception) {
+        bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nm1_5(" << sign << ")";
@@ -531,7 +531,7 @@ void so_reduce_se_part_test::test_nm1_5(
         partitioning (only projected dims are partitioned)
  **/
 void so_reduce_se_part_test::test_nm1_6(
-        bool sign) throw(libtest::test_exception) {
+        bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nm1_6(" << sign << ")";
@@ -621,7 +621,7 @@ void so_reduce_se_part_test::test_nm1_6(
         partitioning (only projected dims are partitioned)
  **/
 void so_reduce_se_part_test::test_nm1_7(
-        bool sign) throw(libtest::test_exception) {
+        bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nm1_7(" << (sign ? '+' : '-') << ")";
@@ -703,7 +703,7 @@ void so_reduce_se_part_test::test_nm1_7(
 /** \test Projection of a 4-space onto a 2-space in two steps.
  **/
 void so_reduce_se_part_test::test_nmk_1(
-        bool sign) throw(libtest::test_exception) {
+        bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nmk_1(" << sign << ")";
@@ -806,7 +806,7 @@ void so_reduce_se_part_test::test_nmk_1(
 /** \test Projection of a 6-space onto a 2-space in two steps.
  **/
 void so_reduce_se_part_test::test_nmk_2(
-        bool s1, bool s2) throw(libtest::test_exception) {
+        bool s1, bool s2) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_part_test::test_nmk_2(" << s1 << ", " << s2 << ")";

--- a/tests/symmetry/so_reduce_se_part_test.h
+++ b/tests/symmetry/so_reduce_se_part_test.h
@@ -14,20 +14,20 @@ namespace libtensor {
  **/
 class so_reduce_se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2() throw(libtest::test_exception);
-    void test_nm1_1(bool sign) throw(libtest::test_exception);
-    void test_nm1_2(bool s1, bool s2) throw(libtest::test_exception);
-    void test_nm1_3(bool sign) throw(libtest::test_exception);
-    void test_nm1_4(bool sign) throw(libtest::test_exception);
-    void test_nm1_5(bool sign) throw(libtest::test_exception);
-    void test_nm1_6(bool sign) throw(libtest::test_exception);
-    void test_nm1_7(bool sign) throw(libtest::test_exception);
-    void test_nmk_1(bool sign) throw(libtest::test_exception);
-    void test_nmk_2(bool s1, bool s2) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2();
+    void test_nm1_1(bool sign);
+    void test_nm1_2(bool s1, bool s2);
+    void test_nm1_3(bool sign);
+    void test_nm1_4(bool sign);
+    void test_nm1_5(bool sign);
+    void test_nm1_6(bool sign);
+    void test_nm1_7(bool sign);
+    void test_nmk_1(bool sign);
+    void test_nmk_2(bool s1, bool s2);
 
 };
 

--- a/tests/symmetry/so_reduce_se_perm_test.C
+++ b/tests/symmetry/so_reduce_se_perm_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void so_reduce_se_perm_test::perform() throw(libtest::test_exception) {
+void so_reduce_se_perm_test::perform() {
 
     test_empty_1();
     test_empty_2();
@@ -23,7 +23,7 @@ void so_reduce_se_perm_test::perform() throw(libtest::test_exception) {
 /** \test Tests that a single reduction step on an empty group yields an empty
         group of lower order
  **/
-void so_reduce_se_perm_test::test_empty_1() throw(libtest::test_exception) {
+void so_reduce_se_perm_test::test_empty_1() {
 
     static const char *testname = "so_reduce_se_perm_test::test_empty_1()";
 
@@ -58,7 +58,7 @@ void so_reduce_se_perm_test::test_empty_1() throw(libtest::test_exception) {
 /** \test Tests that two reduction steps on an empty group yield an empty
         group of lower order
  **/
-void so_reduce_se_perm_test::test_empty_2() throw(libtest::test_exception) {
+void so_reduce_se_perm_test::test_empty_2() {
 
     static const char *testname = "so_reduce_se_perm_test::test_empty_2()";
 
@@ -95,7 +95,7 @@ void so_reduce_se_perm_test::test_empty_2() throw(libtest::test_exception) {
         result: C1 in 1-space. Symmetric elements.
  **/
 void so_reduce_se_perm_test::test_nm1_1(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_perm_test::test_nm1_1(" << symm << ")";
@@ -139,7 +139,7 @@ void so_reduce_se_perm_test::test_nm1_1(
         step. Expected result: C1 in 1-space. Symmetric elements.
  **/
 void so_reduce_se_perm_test::test_nm1_2(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_perm_test::test_nm1_2(" << symm << ")";
@@ -201,7 +201,7 @@ void so_reduce_se_perm_test::test_nm1_2(
         2-space untouched by the masks. Expected result: 2-cycle in 2-space.
  **/
 void so_reduce_se_perm_test::test_nmk_1(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_perm_test::test_nmk_1(" << symm << ")";
@@ -264,7 +264,7 @@ void so_reduce_se_perm_test::test_nmk_1(
         3-space with one dimension out. Expected result: S2(+/-) in 3-space.
  **/
 void so_reduce_se_perm_test::test_nmk_2(
-        bool symm) throw(libtest::test_exception) {
+        bool symm) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_perm_test::test_nmk_2(" << symm << ")";
@@ -326,7 +326,7 @@ void so_reduce_se_perm_test::test_nmk_2(
 /** \test Projection of a group in 8-space in two reduction steps on to 4-space.
  **/
 void so_reduce_se_perm_test::test_nmk_3(
-        bool symm1, bool symm2) throw(libtest::test_exception) {
+        bool symm1, bool symm2) {
 
     std::ostringstream tnss;
     tnss << "so_reduce_se_perm_test::test_nmk_3(" <<

--- a/tests/symmetry/so_reduce_se_perm_test.h
+++ b/tests/symmetry/so_reduce_se_perm_test.h
@@ -14,16 +14,16 @@ namespace libtensor {
  **/
 class so_reduce_se_perm_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2() throw(libtest::test_exception);
-    void test_nm1_1(bool symm) throw(libtest::test_exception);
-    void test_nm1_2(bool symm) throw(libtest::test_exception);
-    void test_nmk_1(bool symm) throw(libtest::test_exception);
-    void test_nmk_2(bool symm) throw(libtest::test_exception);
-    void test_nmk_3(bool symm1, bool symm2) throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2();
+    void test_nm1_1(bool symm);
+    void test_nm1_2(bool symm);
+    void test_nmk_1(bool symm);
+    void test_nmk_2(bool symm);
+    void test_nmk_3(bool symm1, bool symm2);
 
 };
 

--- a/tests/symmetry/so_reduce_test.C
+++ b/tests/symmetry/so_reduce_test.C
@@ -7,7 +7,7 @@
 namespace libtensor {
 
 
-void so_reduce_test::perform() throw(libtest::test_exception) {
+void so_reduce_test::perform() {
 
     test_1();
     test_2();
@@ -18,7 +18,7 @@ void so_reduce_test::perform() throw(libtest::test_exception) {
 /** \test Invokes a projection of C1 in 4-space onto 2-space.
         Expects C1 in 2-space.
  **/
-void so_reduce_test::test_1() throw(libtest::test_exception) {
+void so_reduce_test::test_1() {
 
     static const char *testname = "so_reduce_test::test_1()";
 
@@ -60,7 +60,7 @@ void so_reduce_test::test_1() throw(libtest::test_exception) {
 /** \test Invokes a double projection of S5(+) in 5-space onto 2-space.
         Expects S2(+) in 2-space.
  **/
-void so_reduce_test::test_2() throw(libtest::test_exception) {
+void so_reduce_test::test_2() {
 
     static const char *testname = "so_reduce_test::test_2()";
 
@@ -107,7 +107,7 @@ void so_reduce_test::test_2() throw(libtest::test_exception) {
 
 /** \test Invokes a projection of S2(+) onto 0-space.
  **/
-void so_reduce_test::test_3() throw(libtest::test_exception) {
+void so_reduce_test::test_3() {
 
     static const char *testname = "so_reduce_test::test_3()";
 
@@ -139,7 +139,7 @@ void so_reduce_test::test_3() throw(libtest::test_exception) {
 
 /** \test Invokes a projection of S2(+) onto 2-space.
  **/
-void so_reduce_test::test_4() throw(libtest::test_exception) {
+void so_reduce_test::test_4() {
 
     static const char *testname = "so_reduce_test::test_4()";
 

--- a/tests/symmetry/so_reduce_test.h
+++ b/tests/symmetry/so_reduce_test.h
@@ -11,13 +11,13 @@ namespace libtensor {
 **/
 class so_reduce_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
 
 };
 

--- a/tests/symmetry/so_symmetrize_se_label_test.C
+++ b/tests/symmetry/so_symmetrize_se_label_test.C
@@ -5,7 +5,7 @@
 
 namespace libtensor {
 
-void so_symmetrize_se_label_test::perform() throw(libtest::test_exception) {
+void so_symmetrize_se_label_test::perform() {
 
     std::string table_id = "S6";
     setup_pg_table(table_id);
@@ -31,7 +31,7 @@ void so_symmetrize_se_label_test::perform() throw(libtest::test_exception) {
         empty group
  **/
 void so_symmetrize_se_label_test::test_empty(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_symmetrize_se_label_test::test_empty(" << table_id << ")";
@@ -69,7 +69,7 @@ void so_symmetrize_se_label_test::test_empty(
 /** \test Symmetrization of 2 dim of a 4-space.
  **/
 void so_symmetrize_se_label_test::test_sym2_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_symmetrize_se_label_test::test_sym2_1(" << table_id << ")";
@@ -160,7 +160,7 @@ void so_symmetrize_se_label_test::test_sym2_1(
 /** \test Symmetrization of 2 dim of a 4-space.
  **/
 void so_symmetrize_se_label_test::test_sym2_2(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_symmetrize_se_label_test::test_sym2_2(" << table_id << ")";
@@ -259,7 +259,7 @@ void so_symmetrize_se_label_test::test_sym2_2(
 /** \test Double symmetrization of 2 dim of a 4-space.
  **/
 void so_symmetrize_se_label_test::test_sym2_3(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_symmetrize_se_label_test::test_sym2_3(" << table_id << ")";
@@ -357,7 +357,7 @@ void so_symmetrize_se_label_test::test_sym2_3(
 /** \test Symmetrization of 3 dim of a 3-space.
  **/
 void so_symmetrize_se_label_test::test_sym3_1(
-        const std::string &table_id) throw(libtest::test_exception) {
+        const std::string &table_id) {
 
     std::ostringstream tnss;
     tnss << "so_symmetrize_se_label_test::test_sym3_1(" << table_id << ")";

--- a/tests/symmetry/so_symmetrize_se_label_test.h
+++ b/tests/symmetry/so_symmetrize_se_label_test.h
@@ -11,19 +11,19 @@ namespace libtensor {
  **/
 class so_symmetrize_se_label_test : public se_label_test_base {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
     void test_empty(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_sym2_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_sym2_2(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_sym2_3(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
     void test_sym3_1(
-            const std::string &table_id) throw(libtest::test_exception);
+            const std::string &table_id);
 
     using se_label_test_base::setup_pg_table;
     using se_label_test_base::check_allowed;

--- a/tests/symmetry/so_symmetrize_se_part_test.C
+++ b/tests/symmetry/so_symmetrize_se_part_test.C
@@ -6,7 +6,7 @@
 
 namespace libtensor {
 
-void so_symmetrize_se_part_test::perform() throw(libtest::test_exception) {
+void so_symmetrize_se_part_test::perform() {
 
     test_empty_1();
     test_empty_2();
@@ -18,7 +18,7 @@ void so_symmetrize_se_part_test::perform() throw(libtest::test_exception) {
 /** \test Tests that pair symmetrization of an empty group yields an
         empty group
  **/
-void so_symmetrize_se_part_test::test_empty_1() throw(libtest::test_exception) {
+void so_symmetrize_se_part_test::test_empty_1() {
 
     static const char *testname = "so_symmetrize_se_part_test::test_empty_1()";
 
@@ -54,7 +54,7 @@ void so_symmetrize_se_part_test::test_empty_1() throw(libtest::test_exception) {
 
 /** \test Tests that a symmetrization of an empty group yields an empty group
  **/
-void so_symmetrize_se_part_test::test_empty_2() throw(libtest::test_exception) {
+void so_symmetrize_se_part_test::test_empty_2() {
 
     static const char *testname = "so_symmetrize_se_part_test::test_empty_2()";
 

--- a/tests/symmetry/so_symmetrize_se_part_test.C
+++ b/tests/symmetry/so_symmetrize_se_part_test.C
@@ -88,8 +88,7 @@ void so_symmetrize_se_part_test::test_empty_2() {
 
 /** \test Pair symmetrization of a group in 4-space.
  **/
-void so_symmetrize_se_part_test::test_sym2_1(bool sign)
-throw(libtest::test_exception) {
+void so_symmetrize_se_part_test::test_sym2_1(bool sign) {
 
     std::ostringstream tnss;
     tnss << "so_symmetrize_se_part_test::test_sym2_1(" << sign << ")";
@@ -171,8 +170,7 @@ throw(libtest::test_exception) {
 
 /** \test Anti-symmetrization of a group in 4-space.
  **/
-void so_symmetrize_se_part_test::test_sym2_2()
-throw(libtest::test_exception) {
+void so_symmetrize_se_part_test::test_sym2_2() {
 
     std::ostringstream tnss;
     tnss << "so_symmetrize_se_part_test::test_sym2_2()";

--- a/tests/symmetry/so_symmetrize_se_part_test.h
+++ b/tests/symmetry/so_symmetrize_se_part_test.h
@@ -14,13 +14,13 @@ namespace libtensor {
  **/
 class so_symmetrize_se_part_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_empty_1() throw(libtest::test_exception);
-    void test_empty_2() throw(libtest::test_exception);
-    void test_sym2_1(bool sign) throw(libtest::test_exception);
-    void test_sym2_2() throw(libtest::test_exception);
+    void test_empty_1();
+    void test_empty_2();
+    void test_sym2_1(bool sign);
+    void test_sym2_2();
 
 };
 

--- a/tests/symmetry/so_symmetrize_test.C
+++ b/tests/symmetry/so_symmetrize_test.C
@@ -9,7 +9,7 @@
 namespace libtensor {
 
 
-void so_symmetrize_test::perform() throw(libtest::test_exception) {
+void so_symmetrize_test::perform() {
 
     test_1();
     test_2();
@@ -21,7 +21,7 @@ void so_symmetrize_test::perform() throw(libtest::test_exception) {
 
 /** \test Symmetrization of empty symmetry in 2-space.
  **/
-void so_symmetrize_test::test_1() throw(libtest::test_exception) {
+void so_symmetrize_test::test_1() {
 
     static const char *testname = "so_symmetrize_test::test_1()";
 
@@ -56,7 +56,7 @@ void so_symmetrize_test::test_1() throw(libtest::test_exception) {
 
 /** \test Anti-symmetrization of empty symmetry in 2-space.
  **/
-void so_symmetrize_test::test_2() throw(libtest::test_exception) {
+void so_symmetrize_test::test_2() {
 
     static const char *testname = "so_symmetrize_test::test_2()";
 
@@ -91,7 +91,7 @@ void so_symmetrize_test::test_2() throw(libtest::test_exception) {
 
 /** \test Symmetrization of S2*S2 in 4-space.
  **/
-void so_symmetrize_test::test_3() throw(libtest::test_exception) {
+void so_symmetrize_test::test_3() {
 
     static const char *testname = "so_symmetrize_test::test_3()";
 
@@ -135,7 +135,7 @@ void so_symmetrize_test::test_3() throw(libtest::test_exception) {
 
 /** \test Symmetrization of 2x2 partition symmetry in 2-space.
  **/
-void so_symmetrize_test::test_4() throw(libtest::test_exception) {
+void so_symmetrize_test::test_4() {
 
     static const char *testname = "so_symmetrize_test::test_4()";
 
@@ -180,7 +180,7 @@ void so_symmetrize_test::test_4() throw(libtest::test_exception) {
 /** \test Symmetrization of mixed perm/part symmetry in 4-space.
         Case for \f$ b_{ijkl} = P_+(ij) a_{ik} a_{jl} \f$.
  **/
-void so_symmetrize_test::test_5() throw(libtest::test_exception) {
+void so_symmetrize_test::test_5() {
 
     static const char *testname = "so_symmetrize_test::test_5()";
 

--- a/tests/symmetry/so_symmetrize_test.h
+++ b/tests/symmetry/so_symmetrize_test.h
@@ -11,14 +11,14 @@ namespace libtensor {
 **/
 class so_symmetrize_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
-    void test_3() throw(libtest::test_exception);
-    void test_4() throw(libtest::test_exception);
-    void test_5() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
+    void test_3();
+    void test_4();
+    void test_5();
 
 };
 

--- a/tests/symmetry/symmetry_element_set_adapter_test.C
+++ b/tests/symmetry/symmetry_element_set_adapter_test.C
@@ -5,7 +5,7 @@ namespace libtensor {
 
 
 void symmetry_element_set_adapter_test::perform()
-    throw(libtest::test_exception) {
+    {
 
     test_1();
     test_2();
@@ -50,7 +50,7 @@ using namespace symmetry_element_set_adapter_test_ns;
 /** \test Tests the construction and iterators on the empty set
  **/
 void symmetry_element_set_adapter_test::test_1()
-    throw(libtest::test_exception) {
+    {
 
     static const char *testname =
         "symmetry_element_set_adapter_test::test_1()";
@@ -83,7 +83,7 @@ void symmetry_element_set_adapter_test::test_1()
 /** \test Tests the type conversion by the adapter
  **/
 void symmetry_element_set_adapter_test::test_2()
-    throw(libtest::test_exception) {
+    {
 
     static const char *testname =
         "symmetry_element_set_adapter_test::test_2()";

--- a/tests/symmetry/symmetry_element_set_adapter_test.h
+++ b/tests/symmetry/symmetry_element_set_adapter_test.h
@@ -11,11 +11,11 @@ namespace libtensor {
  **/
 class symmetry_element_set_adapter_test : public libtest::unit_test {
 public:
-    virtual void perform() throw(libtest::test_exception);
+    virtual void perform();
 
 private:
-    void test_1() throw(libtest::test_exception);
-    void test_2() throw(libtest::test_exception);
+    void test_1();
+    void test_2();
 
 };
 


### PR DESCRIPTION
This pull request also removes all references to the (deprecated) register keyword.

Please test this code, my pc overheats when compiling this code and shuts down due to bad wheater (and bad computer).