### PR TITLE
new mkl build

### DIFF
--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -19,4 +19,4 @@ c_compiler_version:
 
 # <<< Other Stuff >>>
 mkl:
-    - 2019.*
+    - 2021

--- a/conda/meta.yaml.in
+++ b/conda/meta.yaml.in
@@ -5,10 +5,6 @@ package:
 source:
     path: ../
 
-build:
-  ignore_run_exports:
-    - mkl
-
 requirements:
   build:
     - {{ compiler('c') }}
@@ -23,7 +19,6 @@ requirements:
     - mkl-devel {{ mkl }}
 
   run:
-    - {{ pin_compatible('mkl', upper_bound='2021.0') }}
     - intel-openmp           # [linux]
 
 files:


### PR DESCRIPTION
Hi! Psi4 is finally modernizing its mkl pinning from (2019.4, 2021) to (2021.4, 2022). I'd like to request a rebuild of libtensorlight for the adcc channel. This PR hasn't been tested, but it's roughly the right changes to make. Fortunately, it's a simplification from the odd pinning we had before. Is a rebuild likely?