### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       shell: bash
       run: |
         ccache --max-size 2G
-        CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ ./build_libtensor.py -v -d ${{runner.workspace}}/build --install ${{runner.workspace}}/install --type Release --features libxm
+        CC=/opt/homebrew/opt/llvm/bin/clang CXX=/opt/homebrew/opt/llvm/bin/clang++ ./build_libtensor.py -v -d ${{runner.workspace}}/build --install ${{runner.workspace}}/install --type Release --features libxm
 
     - name: Test
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies on Linux
       run: |
         sudo apt-get install libopenblas-dev ninja-build ccache
@@ -26,7 +26,7 @@ jobs:
         brew install ninja ccache libomp cmake llvm
         brew install coreutils || true
       if: contains( matrix.os, 'macos')
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       env:
         cache-name: cache-artifacts
       with:
@@ -61,7 +61,7 @@ jobs:
         ./scripts/pack_release.py ${{runner.workspace}}/install
 
     - name: Upload tarball as artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: libtensorlight-${{ matrix.os }}
         path: libtensorlight-*.tar.gz
@@ -71,7 +71,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Glob asset paths

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
     - name: Bundle tarball
       shell: bash
       run: |
+        python -m pip install --user -U setuptools
         ./scripts/pack_release.py ${{runner.workspace}}/install
 
     - name: Upload tarball as artefact

--- a/scripts/pack_release.py
+++ b/scripts/pack_release.py
@@ -28,8 +28,14 @@ git_revision = subprocess.check_output(["git", "rev-parse", "HEAD"],
                                        universal_newlines=True).strip()
 git_tag = subprocess.check_output(["git", "tag", "--points-at", git_revision],
                                   universal_newlines=True).strip()
-if not re.match("^v([0-9.]+)$", git_tag):
+if git_tag.startswith(f"v{ltl_version}"):
+    # allow any tag of the form v[version][suffix] with an arbitrary suffix
+    # However, the CI requires that there are no '-' in the suffix
+    ltl_version = git_tag.replace('-', '_')
+else:
     ltl_version = ltl_version + ".dev"
 
 filename = f"libtensorlight-{ltl_version}-{platform}.tar.gz"
-subprocess.check_call(["tar", "-C", install_dir, "-czf", filename, "include", "lib"])
+subprocess.check_call(
+    ["tar", "-C", install_dir, "-czf", filename, "include", "lib"]
+)


### PR DESCRIPTION
Try upgrading the CI for macos arm64, because we need the arm64 binaries for the adcc CI. However, this means that osx x86_64 binaries will only be available through conda.